### PR TITLE
feat: LLM 프롬프트 한국어화 및 causal_chains 미사용 컬럼 활성화

### DIFF
--- a/prd/db/factory.py
+++ b/prd/db/factory.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from prd.db.postgres_repository import PostgresRepository
 from prd.db.supabase_client import create_sb, is_supabase_configured
-from prd.db.supabase_repository import SupabaseRepository
 
 
-def create_repository() -> PostgresRepository | SupabaseRepository:
+def create_repository():
     if is_supabase_configured():
+        from prd.db.supabase_repository import SupabaseRepository
         return SupabaseRepository(create_sb())
 
+    from prd.db.postgres_repository import PostgresRepository
     from prd.db.connection import get_connection
     return PostgresRepository(get_connection())

--- a/prd/db/save.py
+++ b/prd/db/save.py
@@ -14,9 +14,10 @@ def save_analysis_result(connection, raw_news_id: str, result: dict) -> None:
         INSERT INTO news_analyses (
             raw_news_id, summary, reliability, related_indicators,
             reliability_reason, time_horizon, effect_chain,
-            buffer, leading_indicator, geo_scope
+            buffer, leading_indicator, geo_scope,
+            article_scope, korea_relevance
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         RETURNING id;
     """
     sql_update = """
@@ -30,6 +31,8 @@ def save_analysis_result(connection, raw_news_id: str, result: dict) -> None:
             buffer             = %s,
             leading_indicator  = %s,
             geo_scope          = %s,
+            article_scope      = %s,
+            korea_relevance    = %s,
             updated_at         = NOW()
         WHERE id = %s
         RETURNING id;
@@ -39,8 +42,12 @@ def save_analysis_result(connection, raw_news_id: str, result: dict) -> None:
         INSERT INTO causal_chains
             (news_analysis_id, event, mechanism,
              category, direction, magnitude,
-             change_pct_min, change_pct_max, monthly_impact)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);
+             change_pct_min, change_pct_max, monthly_impact,
+             raw_shock_percent, raw_shock_rationale,
+             transmission_time_months, transmission_rationale,
+             wallet_hit_percent, raw_shock_factors,
+             wallet_hit_factors, logic_steps)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
     """
 
     try:
@@ -57,6 +64,8 @@ def save_analysis_result(connection, raw_news_id: str, result: dict) -> None:
             result.get("buffer") or "",
             result.get("leading_indicator"),
             result.get("geo_scope"),
+            result.get("article_scope"),
+            result.get("korea_relevance"),
         )
 
         with connection.cursor() as cursor:
@@ -74,6 +83,7 @@ def save_analysis_result(connection, raw_news_id: str, result: dict) -> None:
 
         with connection.cursor() as cursor:
             for effect in result.get("effects", []):
+                import json as _json
                 cursor.execute(
                     sql_causal,
                     (
@@ -86,6 +96,14 @@ def save_analysis_result(connection, raw_news_id: str, result: dict) -> None:
                         effect.get("change_pct_min"),
                         effect.get("change_pct_max"),
                         effect.get("monthly_impact"),
+                        effect.get("raw_shock_percent", 0),
+                        effect.get("raw_shock_rationale", ""),
+                        effect.get("transmission_time_months", 1),
+                        effect.get("transmission_rationale", ""),
+                        effect.get("wallet_hit_percent", 0),
+                        effect.get("raw_shock_factors", []),
+                        effect.get("wallet_hit_factors", []),
+                        _json.dumps(effect.get("logic_steps", []), ensure_ascii=False),
                     ),
                 )
 

--- a/prd/db/supabase_store.py
+++ b/prd/db/supabase_store.py
@@ -143,6 +143,8 @@ def save_analysis_result_sb(sb: Any, raw_news_id: str, result: dict) -> None:
                 "buffer": result.get("buffer") or "",
                 "leading_indicator": result.get("leading_indicator"),
                 "geo_scope": result.get("geo_scope"),
+                "article_scope": result.get("article_scope"),
+                "korea_relevance": result.get("korea_relevance"),
             }
         )
         .execute()
@@ -165,6 +167,14 @@ def save_analysis_result_sb(sb: Any, raw_news_id: str, result: dict) -> None:
                     "change_pct_min": effect.get("change_pct_min"),
                     "change_pct_max": effect.get("change_pct_max"),
                     "monthly_impact": effect.get("monthly_impact"),
+                    "raw_shock_percent": effect.get("raw_shock_percent", 0),
+                    "raw_shock_rationale": effect.get("raw_shock_rationale", ""),
+                    "transmission_time_months": effect.get("transmission_time_months", 1),
+                    "transmission_rationale": effect.get("transmission_rationale", ""),
+                    "wallet_hit_percent": effect.get("wallet_hit_percent", 0),
+                    "raw_shock_factors": effect.get("raw_shock_factors", []),
+                    "wallet_hit_factors": effect.get("wallet_hit_factors", []),
+                    "logic_steps": effect.get("logic_steps", []),
                 }
             ).execute()
     except Exception:

--- a/prd/llm/chains/category_registry.py
+++ b/prd/llm/chains/category_registry.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from prd.db.connection import get_connection
-from prd.db.fetch import fetch_active_cost_categories
-
 DEFAULT_ALLOWED_CATEGORIES = (
     "oil",
     "fuel",
@@ -72,6 +69,8 @@ def _default_category_dicts() -> tuple[dict, ...]:
 @lru_cache(maxsize=1)
 def get_allowed_categories() -> tuple[dict, ...]:
     try:
+        from prd.db.connection import get_connection
+        from prd.db.fetch import fetch_active_cost_categories
         connection = get_connection()
     except Exception:
         return _default_category_dicts()

--- a/prd/llm/chains/causal_normalizer.py
+++ b/prd/llm/chains/causal_normalizer.py
@@ -128,6 +128,17 @@ def normalize_causal(
         elif monthly_impact is None:
             monthly_impact = 0
 
+        raw_shock_percent = _to_float(effect.get("raw_shock_percent")) or 0.0
+        raw_shock_rationale = str(effect.get("raw_shock_rationale") or "").strip()
+        transmission_time_months = _to_int(effect.get("transmission_time_months")) or 1
+        transmission_rationale = str(effect.get("transmission_rationale") or "").strip()
+        wallet_hit_percent = _to_float(effect.get("wallet_hit_percent")) or 0.0
+        raw_shock_factors = [str(f).strip() for f in (effect.get("raw_shock_factors") or []) if str(f).strip()]
+        wallet_hit_factors = [str(f).strip() for f in (effect.get("wallet_hit_factors") or []) if str(f).strip()]
+        logic_steps = effect.get("logic_steps") or []
+        if not isinstance(logic_steps, list):
+            logic_steps = []
+
         normalized_effects.append(
             {
                 "category": category,
@@ -136,6 +147,14 @@ def normalize_causal(
                 "change_pct_min": change_pct_min,
                 "change_pct_max": change_pct_max,
                 "monthly_impact": monthly_impact,
+                "raw_shock_percent": raw_shock_percent,
+                "raw_shock_rationale": raw_shock_rationale,
+                "transmission_time_months": transmission_time_months,
+                "transmission_rationale": transmission_rationale,
+                "wallet_hit_percent": wallet_hit_percent,
+                "raw_shock_factors": raw_shock_factors,
+                "wallet_hit_factors": wallet_hit_factors,
+                "logic_steps": logic_steps,
             }
         )
 
@@ -191,7 +210,10 @@ def normalize_causal(
         "leading_indicator": _normalize_enum(out.get("leading_indicator"), ALLOWED_LEADING_INDICATORS),
         "geo_scope": _normalize_enum(out.get("geo_scope"), ALLOWED_GEO_SCOPES),
         "article_scope": _normalize_enum(out.get("article_scope"), ALLOWED_ARTICLE_SCOPES),
-        "korea_relevance": _normalize_enum(out.get("korea_relevance"), ALLOWED_KOREA_RELEVANCE),
+        "korea_relevance": _normalize_korea_relevance(
+            out.get("korea_relevance"),
+            article_scope=_normalize_enum(out.get("article_scope"), ALLOWED_ARTICLE_SCOPES),
+        ),
     }
     return CausalResult.model_validate(normalized).model_dump()
 
@@ -348,6 +370,13 @@ def _derive_magnitude_from_range(
     if peak >= MAGNITUDE_BANDS["medium"][0]:
         return "medium"
     return "low"
+
+
+def _normalize_korea_relevance(value: Any, *, article_scope: str | None) -> str | None:
+    korea_relevance = _normalize_enum(value, ALLOWED_KOREA_RELEVANCE)
+    if korea_relevance == "direct" and article_scope not in (None, "korea"):
+        return "indirect"
+    return korea_relevance
 
 
 def _normalize_enum(value: Any, allowed: set[str]) -> str | None:

--- a/prd/llm/graph/news_pipeline_graph.py
+++ b/prd/llm/graph/news_pipeline_graph.py
@@ -147,9 +147,14 @@ def _summary_has_minimum_format(summary: str) -> bool:
     return all(_extract_summary_field(summary, field) for field in required)
 
 
+def _extract_summary_ko(summary: str) -> str:
+    return _extract_summary_field(summary, "summary_ko")
+
+
 def _summary_has_grounding_issue(content: str, summary: str) -> bool:
     content_lower = (content or "").lower()
-    summary_lower = (summary or "").lower()
+    summary_without_ko = re.sub(r"(?im)^summary_ko:.*$", "", summary or "")
+    summary_lower = summary_without_ko.lower()
 
     # 숫자 일치 체크 제거: LLM이 단위 변환($→p, gallon→litre 등)하면 오탐 발생
     # 키워드 기반 체크만 유지: 요약에 inflation/CPI 등이 등장했는데 기사에 전혀 없으면 hallucination
@@ -186,10 +191,11 @@ def _cost_signal_is_core_topic(title: str, content: str, summary: str) -> bool:
 
 
 def _skip_from_summary(summary: str, event: str, reason: str) -> dict[str, Any]:
+    summary_ko = _extract_summary_ko(summary)
     return {
         "summary": summary,
         "result": {
-            "summary": summary,
+            "summary": summary_ko,
             "event": event,
             "mechanism": "",
             "related_indicators": [],
@@ -558,7 +564,7 @@ def validate_causal_node(state: NewsState) -> NewsState:
             elapsed = time.perf_counter() - started_at
             print(f"[validate][news_id={news_id}] elapsed={elapsed:.2f}s result=skip(empty_effects)")
             return {
-                "result": {"summary": state["summary"], **causal, "_skip": True},
+                "result": {"summary": _extract_summary_ko(state["summary"]), **causal, "_skip": True},
                 "error": "",
                 "stage": "validate_causal",
                 "trace": _append_trace(
@@ -570,7 +576,7 @@ def validate_causal_node(state: NewsState) -> NewsState:
                 ),
             }
         validate_causal_result(causal, summary=state.get("summary", ""))
-        result = {"summary": state["summary"], **causal}
+        result = {"summary": _extract_summary_ko(state["summary"]), **causal}
         elapsed = time.perf_counter() - started_at
         print(f"[validate][news_id={news_id}] elapsed={elapsed:.2f}s result=success")
         return {

--- a/prd/llm/prompts/causal_prompt.py
+++ b/prd/llm/prompts/causal_prompt.py
@@ -4,7 +4,7 @@ from langchain_core.prompts import ChatPromptTemplate
 
 
 def _build_category_block(categories: list[dict]) -> str:
-    items = categories or [{"code": "fuel", "name_ko": "fuel", "keywords": ["gasoline", "diesel"]}]
+    items = categories or [{"code": "fuel", "name_ko": "연료", "keywords": ["휘발유", "경유"]}]
     result: list[str] = []
     for cat in items:
         code = cat["code"]
@@ -24,64 +24,64 @@ def _build_category_text(categories: list[dict]) -> str:
 def _build_example_json() -> str:
     up_example = (
         "{{"
-        '"event":"Global oil prices rise after supply disruption",'
-        '"mechanism":"A supply shock lifts crude import costs and increases household fuel spending.",'
+        '"event":"공급 차질로 국제유가 상승",'
+        '"mechanism":"공급 충격으로 원유 수입 비용이 오르고 가계 연료비 지출이 증가합니다.",'
         '"related_indicators":["wti"],'
         '"reliability":0.84,'
-        '"reliability_reason":"The article directly links supply disruption, oil price increases, and higher fuel costs.",'
+        '"reliability_reason":"기사가 공급 차질, 유가 상승, 연료비 인상을 직접 연결하고 구체적 수치를 제시합니다.",'
         '"time_horizon":"short",'
-        '"effect_chain":["Supply disruption","Oil price increase","Household fuel cost increase"],'
-        '"buffer":"Possible government subsidy",'
+        '"effect_chain":["공급 차질","유가 상승","가계 연료비 증가"],'
+        '"buffer":"정부 보조금 가능성",'
         '"leading_indicator":"leading",'
         '"geo_scope":"global",'
         '"article_scope":"global",'
         '"korea_relevance":"indirect",'
-        '"effects":[{{"category":"fuel","direction":"up","magnitude":"medium","change_pct_min":2.0,"change_pct_max":5.0,"monthly_impact":15000}}]'
+        '"effects":[{{"category":"fuel","direction":"up","magnitude":"medium","change_pct_min":2.0,"change_pct_max":5.0,"monthly_impact":15000,"raw_shock_percent":5.0,"raw_shock_rationale":"WTI 약 5% 상승 명시","transmission_time_months":1,"transmission_rationale":"국내 정유사 가격 반영 주기 약 1개월","wallet_hit_percent":3.0,"raw_shock_factors":["OPEC 감산","공급 차질"],"wallet_hit_factors":["정유사 마진","유류세 반영"],"logic_steps":[{{"step":1,"description":"OPEC 감산 합의"}},{{"step":2,"description":"WTI 5% 상승"}},{{"step":3,"description":"국내 휘발유 가격 인상"}}]}}]'
         "}}"
     )
     down_example = (
         "{{"
-        '"event":"Output increase pushes oil prices lower",'
-        '"mechanism":"Higher supply lowers crude prices and reduces household fuel spending.",'
+        '"event":"증산으로 국제유가 하락",'
+        '"mechanism":"공급 증가로 원유 가격이 내리고 가계 연료비 지출이 감소합니다.",'
         '"related_indicators":["wti"],'
         '"reliability":0.82,'
-        '"reliability_reason":"The article directly links higher supply, lower oil prices, and lower fuel costs.",'
+        '"reliability_reason":"기사가 공급 증가, 유가 하락, 연료비 감소를 직접 연결하고 구체적 수치를 제시합니다.",'
         '"time_horizon":"short",'
-        '"effect_chain":["Supply increase","Oil price decline","Household fuel cost decline"],'
+        '"effect_chain":["공급 증가","유가 하락","가계 연료비 감소"],'
         '"buffer":"",'
         '"leading_indicator":"leading",'
         '"geo_scope":"global",'
         '"article_scope":"global",'
         '"korea_relevance":"indirect",'
-        '"effects":[{{"category":"fuel","direction":"down","magnitude":"medium","change_pct_min":-5.0,"change_pct_max":-2.0,"monthly_impact":-12000}}]'
+        '"effects":[{{"category":"fuel","direction":"down","magnitude":"medium","change_pct_min":-5.0,"change_pct_max":-2.0,"monthly_impact":-12000,"raw_shock_percent":-5.0,"raw_shock_rationale":"WTI 약 5% 하락 명시","transmission_time_months":1,"transmission_rationale":"국내 정유사 가격 반영 주기 약 1개월","wallet_hit_percent":-3.0,"raw_shock_factors":["OPEC 증산","공급 증가"],"wallet_hit_factors":["정유사 마진 축소","유류세 반영"],"logic_steps":[{{"step":1,"description":"공급 증가"}},{{"step":2,"description":"WTI 5% 하락"}},{{"step":3,"description":"국내 휘발유 가격 인하"}}]}}]'
         "}}"
     )
-    neutral_example1 = (
+    neutral_with_effects = (
         "{{"
-        '"event":"Supply talks fail but no immediate price change",'
-        '"mechanism":"Negotiation failure increases uncertainty, but the article does not show a clear household cost move.",'
+        '"event":"공급 협상 결렬, 즉각적 가격 변동 없음",'
+        '"mechanism":"협상 결렬로 불확실성이 높아졌으나 가계 비용 변화는 기사에 명시되지 않았습니다.",'
         '"related_indicators":["wti"],'
         '"reliability":0.55,'
-        '"reliability_reason":"The article mentions uncertainty but no clear pass-through to household prices.",'
+        '"reliability_reason":"기사가 불확실성을 언급하나 가계 가격 전가 수치가 없습니다.",'
         '"time_horizon":"short",'
-        '"effect_chain":["Failed talks","Market uncertainty","Limited household cost effect"],'
-        '"buffer":"No realized price move yet",'
+        '"effect_chain":["협상 결렬","시장 불확실성","가계 비용 영향 제한적"],'
+        '"buffer":"아직 실현된 가격 변동 없음",'
         '"leading_indicator":"leading",'
         '"geo_scope":"global",'
         '"article_scope":"global",'
         '"korea_relevance":"indirect",'
-        '"effects":[{{"category":"fuel","direction":"neutral","magnitude":"low","change_pct_min":null,"change_pct_max":null,"monthly_impact":0}}]'
+        '"effects":[{{"category":"fuel","direction":"neutral","magnitude":"low","change_pct_min":null,"change_pct_max":null,"monthly_impact":0,"raw_shock_percent":0,"raw_shock_rationale":"구체적 수치 없음","transmission_time_months":1,"transmission_rationale":"불확실","wallet_hit_percent":0,"raw_shock_factors":[],"wallet_hit_factors":[],"logic_steps":[{{"step":1,"description":"협상 결렬"}},{{"step":2,"description":"불확실성 증가"}}]}}]'
         "}}"
     )
-    neutral_example2 = (
+    neutral_no_effects = (
         "{{"
-        '"event":"Central bank holds rates unchanged",'
-        '"mechanism":"Rate hold keeps borrowing costs stable but does not directly change household fuel or food prices.",'
+        '"event":"중앙은행 기준금리 동결",'
+        '"mechanism":"금리 동결로 차입 비용은 유지되나 가계 연료비·식비에 직접 영향은 없습니다.",'
         '"related_indicators":[],'
         '"reliability":0.45,'
-        '"reliability_reason":"No direct household price number stated in the article.",'
+        '"reliability_reason":"기사에 가계 직접 가격 변화 수치가 없고 소비자 연결이 없습니다.",'
         '"time_horizon":"medium",'
-        '"effect_chain":["Rate hold","Stable borrowing costs","No direct household price change"],'
+        '"effect_chain":["금리 동결","차입 비용 안정","가계 직접 가격 변화 없음"],'
         '"buffer":"",'
         '"leading_indicator":"lagging",'
         '"geo_scope":"global",'
@@ -90,34 +90,15 @@ def _build_example_json() -> str:
         '"effects":[]'
         "}}"
     )
-    neutral_example3 = (
-        "{{"
-        '"event":"Global commodity prices edge higher on demand optimism",'
-        '"mechanism":"Marginal commodity price increase; no specific household price figure in the article.",'
-        '"related_indicators":["wti"],'
-        '"reliability":0.52,'
-        '"reliability_reason":"Article mentions demand optimism but gives no direct household price number.",'
-        '"time_horizon":"short",'
-        '"effect_chain":["Demand optimism","Commodity price uptick","Uncertain household pass-through"],'
-        '"buffer":"Pass-through delay and retail competition",'
-        '"leading_indicator":"leading",'
-        '"geo_scope":"global",'
-        '"article_scope":"global",'
-        '"korea_relevance":"indirect",'
-        '"effects":[{{"category":"energy","direction":"neutral","magnitude":"low","change_pct_min":null,"change_pct_max":null,"monthly_impact":0}}]'
-        "}}"
-    )
     return (
-        "cost_signal: up example (specific % figure present):\n"
+        "cost_signal: up 예시 (구체적 % 수치 있음, consumer_link: yes):\n"
         + up_example
-        + "\n\ncost_signal: down example (specific % figure present):\n"
+        + "\n\ncost_signal: down 예시 (구체적 % 수치 있음, consumer_link: yes):\n"
         + down_example
-        + "\n\nneutral example 1 — no realized price move:\n"
-        + neutral_example1
-        + "\n\nneutral example 2 — macro policy, no direct household price:\n"
-        + neutral_example2
-        + "\n\nneutral example 3 — no specific household price number in article:\n"
-        + neutral_example3
+        + "\n\nneutral 예시 1 — consumer_link: yes이나 수치 없음 → effects에 neutral 포함:\n"
+        + neutral_with_effects
+        + "\n\nneutral 예시 2 — consumer_link: no → effects: []:\n"
+        + neutral_no_effects
     )
 
 
@@ -128,27 +109,30 @@ def build_causal_prompt(categories: list[dict]) -> ChatPromptTemplate:
 
     system_prompt = dedent(
         f"""
-        You convert the article summary into structured causal JSON for consumer cost impact.
+        당신은 기사 요약을 소비자 생활비 영향 인과관계 JSON으로 변환하는 분석기입니다.
 
-        Inputs:
-        - current article summary note
-        - indicator context at article date
-        - historical similar article summaries
-        - allowed consumer-cost categories
+        입력:
+        - 현재 기사 요약
+        - 기사 날짜 기준 경제 지표 컨텍스트
+        - 유사 기사 히스토리 요약
+        - 허용된 소비자 비용 카테고리
 
-        Allowed categories:
+        허용 카테고리:
         {category_block}
 
-        Goals:
-        - Focus only on direct household cost channels.
-        - Be conservative when the evidence is weak.
-        - Output valid JSON only.
+        목표:
+        - 가계 직접 비용 채널에만 집중합니다.
+        - 근거가 약하면 보수적으로 판단합니다.
+        - 유효한 JSON만 출력합니다.
+        - event, mechanism, effect_chain, reliability_reason, buffer는 반드시 한국어로 작성합니다.
 
-        Hard output rules:
-        1. Output a single raw JSON object only. No markdown fences, no explanation text.
-        2. Use only evidence supported by the current article. History and indicators are support context, not primary evidence.
-        3. If the summary shows `cost_signal:none` or `consumer_link:no`, output `effects: []`.
-        4. Use only these enums:
+        출력 규칙:
+        1. 단일 JSON 객체만 출력합니다. 마크다운 펜스, 설명 텍스트 금지.
+        2. 현재 기사 근거만 사용합니다. 히스토리·지표는 보조 맥락입니다.
+        3. 요약의 `consumer_link: no`이면 `effects: []` 출력.
+        4. 요약의 `cost_signal: none`이고 `consumer_link: yes`이면 effects에 direction: neutral 항목을 포함합니다.
+        5. 요약의 `cost_signal: none`이고 `consumer_link: no`이면 `effects: []` 출력.
+        5. 허용 enum만 사용합니다:
            - direction: up | down | neutral
            - magnitude: low | medium | high
            - time_horizon: short | medium | long
@@ -156,79 +140,99 @@ def build_causal_prompt(categories: list[dict]) -> ChatPromptTemplate:
            - geo_scope: global | asia | korea
            - article_scope: korea | uk | europe | asia | middle_east | africa | americas | global | unknown
            - korea_relevance: direct | indirect | none
-        5. Use only these indicator codes when relevant: usd_krw, wti, gold, base_rate.
-        6. Keep `effect_chain` to at most 5 short steps.
-        7. Keep `effects` to at most 3 unique categories.
-        8. If `buffer` is empty, use an empty string.
+        6. 지표 코드는 관련 있을 때만 사용: usd_krw, wti, gold, base_rate
+        7. `effect_chain`은 최대 5단계로 제한합니다.
+        8. `effects`는 최대 3개 카테고리로 제한합니다.
+        9. `buffer`가 없으면 빈 문자열을 사용합니다.
+        10. `mechanism`은 2문장 이내, 100자 이내로 작성합니다.
 
-        Direction rules:
-        9. `direction: neutral` is the DEFAULT. Use `up` or `down` only when the article provides a clear and specific number showing a household price move of 2 % or more.
-        10. Read `cost_signal` first. If `cost_signal: none`, set `effects: []`.
-        11. If `cost_signal: up` or `down`, still use `direction: neutral` unless ALL of the following are true:
-            - The article states a specific percentage or price figure for the household cost move.
-            - The move is 2 % or larger.
-            - The effect reaches consumers directly, not through a long indirect chain.
-            - reliability >= 0.70.
-        12. Use `direction: neutral` and `magnitude: low` if ANY of the following apply:
-            - The article mentions no specific % number or price change figure.
-            - The effect passes through 2 or more intermediate steps before reaching consumers.
-            - Opposing forces exist that may offset the impact.
-            - The article is about policy discussion, forecasts, or warnings — not a realized price change.
-            - geo_scope is global and the article has no explicit Korea household link.
-            - reliability < 0.70.
-        13. In practice, roughly 30–40 % of articles produce a clear up/down signal. The rest are neutral. Do not force up/down.
-        14. Supply increase, tax cut, subsidy expansion, price cut, duty cut, and inventory increase → `down` (when rule 11 is satisfied).
-        15. Supply disruption, tax increase, price rise, duty increase, import cost increase, and shortages → `up` (when rule 11 is satisfied).
+        `korea_relevance` 판단 기준:
+        - `direct`: 기사가 한국 가계 가격·세금·공급에 직접 영향을 명시한 경우
+        - `indirect`: 글로벌 원자재·환율·공급망을 통해 한국에 간접 영향이 예상되는 경우
+        - `none`: 한국과 무관하거나 영향 경로가 없는 경우
 
-        Change-percent rules:
-        16. If the article explicitly states a direct household-price figure, use that number to build a conservative range.
-        16a. Do not copy headline CPI, commodity prices, or producer prices directly into `change_pct` unless the article explicitly says that number is the consumer-facing price move.
-        16b. If the article gives only one exact number, build a range around it (e.g. 4 % → 3.0 to 5.0).
-        17. If the article does NOT provide a specific price figure, set `change_pct_min = null` and `change_pct_max = null`. Do not invent a range.
-        18. For `down`, change_pct values are negative in ascending order, for example `-5.0` to `-2.0`.
-        19. For `up`, change_pct values are positive in ascending order, for example `2.0` to `5.0`.
-        20. For `neutral`, set `change_pct_min = null`, `change_pct_max = null`, and `monthly_impact = 0`.
-        21. If you are unsure about `monthly_impact`, set it to `0`.
+        `reliability` 산정 기준:
+        - 0.80 이상: 기사에 구체적 수치와 직접 가계 가격 연결이 모두 있음
+        - 0.60~0.79: 수치는 있으나 간접 경로이거나, 직접 연결이나 수치 중 하나만 있음
+        - 0.40~0.59: 수치 없이 방향만 언급하거나 불확실성이 높음
+        - 0.40 미만: 소비자 연결이 매우 약하거나 추측에 가까움
 
-        Scope rules:
-        21. Do not create effects for stock-market coverage, corporate earnings, M&A, asset prices, or general politics without direct household pass-through.
-        22. Foreign articles should stay foreign unless the article explicitly states a direct Korea household impact.
-        23. If the article is UK-specific, use `article_scope: uk`. Use `europe`, `americas`, `middle_east`, and others only when clearly supported.
+        direction 판단 규칙:
+        11. `direction: neutral`이 기본값입니다. `up` 또는 `down`은 아래 조건을 모두 충족할 때만 사용합니다:
+            - 기사에 가계 직접 가격 변동의 구체적 수치(%)가 있음
+            - 변동폭 2% 이상
+            - 소비자에게 직접 전가됨 (긴 간접 경로 아님)
+            - reliability >= 0.70
+        12. 아래 중 하나라도 해당하면 `direction: neutral`, `magnitude: low` 사용:
+            - 기사에 구체적 % 수치나 가격 변화 없음
+            - 소비자 도달까지 2단계 이상 간접 경로
+            - 상쇄 요인 존재
+            - 정책 논의·예측·경고 기사 (실현된 가격 변화 아님)
+            - geo_scope가 global이고 한국 가계 직접 연결 없음
+            - reliability < 0.70
+        13. 실제로 약 30~40%의 기사만 명확한 up/down 신호를 가집니다. up/down을 강제하지 마세요.
+        14. 공급 증가·세금 인하·보조금 확대·가격 인하·관세 인하·재고 증가 → `down` (규칙 11 충족 시)
+        15. 공급 차질·세금 인상·가격 인상·관세 인상·수입 비용 증가·공급 부족 → `up` (규칙 11 충족 시)
 
-        Required JSON fields:
-        - event
-        - mechanism
+        change_pct 규칙:
+        16. 기사에 가계 직접 가격 수치가 명시된 경우, 그 수치를 기반으로 보수적 범위를 구성합니다.
+        17. 헤드라인 CPI·원자재 가격·생산자 가격을 `change_pct`에 직접 사용하지 않습니다.
+        18. 하나의 수치만 있으면 범위로 변환합니다 (예: 4% → 3.0~5.0).
+        19. 기사에 구체적 가격 수치가 없으면 `change_pct_min = null`, `change_pct_max = null`.
+        20. `down`이면 음수 오름차순 (예: -5.0 ~ -2.0), `up`이면 양수 오름차순 (예: 2.0 ~ 5.0).
+        21. `neutral`이면 `change_pct_min = null`, `change_pct_max = null`, `monthly_impact = 0`.
+        22. `monthly_impact`가 불확실하면 `0`으로 설정합니다.
+
+        범위 규칙:
+        23. 주가·기업실적·M&A·자산가격·직접 가계 전가 없는 일반 정치 기사는 effects 생성 금지.
+        24. 외국 기사는 한국 가계 직접 영향이 기사에 명시된 경우에만 korea_relevance를 direct로 설정.
+        25. 영국 기사는 `article_scope: uk`, 그 외 지역은 기사에 명확히 언급된 경우에만 설정.
+
+        effects 내 각 항목 필수 필드:
+        - category, direction, magnitude, change_pct_min, change_pct_max, monthly_impact
+        - raw_shock_percent: 원자재 가격 충격률 (%). 수치 없으면 0.
+        - raw_shock_rationale: 충격 근거 한 줄 (한국어). 수치 없으면 "구체적 수치 없음".
+        - transmission_time_months: 소비자 가격 반영까지 예상 월수 (정수). short=1, medium=3, long=6.
+        - transmission_rationale: 전달 시차 근거 한 줄 (한국어).
+        - wallet_hit_percent: 가계 실질 부담 변화율 (%). raw_shock_percent보다 작거나 같음. 수치 없으면 0.
+        - raw_shock_factors: 충격 요인 배열 (한국어, 최대 3개).
+        - wallet_hit_factors: 가계 타격 요인 배열 (한국어, 최대 3개).
+        - logic_steps: 추론 단계 배열. 각 항목은 step(정수)과 description(한국어) 두 키를 가진 객체. 최대 5단계.
+
+        필수 JSON 최상위 필드:
+        - event (한국어, 30자 이내)
+        - mechanism (한국어, 100자 이내)
         - related_indicators
         - reliability
-        - reliability_reason
+        - reliability_reason (한국어)
         - effects
         - time_horizon
-        - effect_chain
-        - buffer
+        - effect_chain (한국어 배열, 최대 5단계)
+        - buffer (한국어 또는 빈 문자열)
         - leading_indicator
         - geo_scope
         - article_scope
         - korea_relevance
 
-        Allowed category codes:
+        허용 카테고리 코드:
         {category_text}
 
-        Output examples:
+        출력 예시:
         {example_json}
         """
     ).strip()
 
     user_prompt = dedent(
         """
-        Output only the JSON object.
+        JSON 객체만 출력하세요.
 
-        [Current article summary]
+        [현재 기사 요약]
         {summary}
 
-        [Indicator context]
+        [경제 지표 컨텍스트]
         {indicator_context}
 
-        [Historical context]
+        [히스토리 컨텍스트]
         {history_context}
         """
     ).strip()

--- a/prd/llm/prompts/summary_prompt.py
+++ b/prd/llm/prompts/summary_prompt.py
@@ -5,56 +5,74 @@ from langchain_core.prompts import ChatPromptTemplate
 
 SUMMARY_SYSTEM_PROMPT = dedent(
     """
-    You are the first-pass classifier for consumer cost news.
+    당신은 소비자 생활비 뉴스의 1차 분류기입니다. 기사 언어에 관계없이 아래 형식으로만 출력합니다.
 
-    Your job is to compress the article into exactly four lines:
+    출력 형식 (5줄 고정, 순서 변경·생략 불가):
     event:
     cost_signal:
     consumer_link:
     facts:
+    summary_ko:
 
-    Output rules:
-    1. Output plain text only. No JSON, markdown, bullets, numbering, or explanations.
-    2. Use only facts directly supported by the article.
-    3. Keep the whole output short and focused on direct consumer cost impact.
-    4. `consumer_link` must be `yes` only when the article clearly affects household spending such as fuel, gas, electricity, utilities, groceries, food, transport, shipping pass-through, taxes, duties, fares, or inflation-facing living costs.
-    5. If the article is mainly about stocks, company earnings, M&A, asset prices, real estate sale prices, politics, culture, or general macro discussion without direct household pass-through, set `consumer_link: no`.
+    출력 규칙:
+    1. 순수 텍스트만 출력합니다. JSON, 마크다운, 번호, 설명 문장 금지.
+    2. 기사에 명시된 사실만 사용합니다. 추측·과장·배경 설명 제거.
+    3. event, facts는 반드시 한국어로 작성합니다. 기사가 영어여도 한국어로 씁니다.
+    4. summary_ko는 반드시 한국어로 작성합니다. 3문장 이내, 300자 이내, 소비자 생활비 영향 중심.
+    5. consumer_link: no 이면 summary_ko는 비워둡니다.
+    6. consumer_link: no 이면 cost_signal은 반드시 none 입니다.
 
-    Hard decision rules for `cost_signal`:
-    - `up`: household-facing prices, bills, fares, taxes, duties, or living costs are rising or likely to rise.
-    - `down`: household-facing prices, bills, fares, taxes, duties, or living costs are falling, cut, reduced, or likely to fall.
-    - `none`: no clear direct consumer-cost effect, or the article contains offsetting up/down signals without a clear net direction.
+    `cost_signal` 판단 기준:
+    - `up`: 가계 필수 지출(연료비·공공요금·식비·세금·운송비 등)이 오르거나 오를 가능성이 있을 때
+    - `down`: 가계 필수 지출이 내리거나 내릴 가능성이 있을 때
+    - `none`: 소비자 직접 영향이 불명확하거나 상승·하락 신호가 혼재하거나 consumer_link가 no일 때
 
-    Additional guidance:
-    - If the article says "price cut", "bill cut", "tax cut", "duty cut", "subsidy expansion", "supply increase", or "inventory increase", prefer `cost_signal: down`.
-    - If the article says "price rise", "bill rise", "tax increase", "duty increase", "shortage", "supply disruption", or "import cost increase", prefer `cost_signal: up`.
-    - If both up and down forces appear, do not guess. Use `cost_signal: none` unless the article clearly states the dominant household effect.
-    - `facts` should contain one or two short evidence points, preferably with numbers when the article provides them.
+    `consumer_link` 판단 기준:
+    - `yes`: 연료비, 에너지비, 가스비, 식비, 곡물·원자재, 운송비, 공공요금, 물가, 세금이 직접 영향받을 때
+    - `no`: 주가, 기업실적, M&A, 부동산 매매가, 정치, 문화, 선택적 소비, 거시경제 논평만 있을 때
+    - 기사 중심 주제 기준으로 판단합니다. 물가 언급이 일부 있어도 핵심이 주식·기업이면 `no`.
+    - 애매하면 `no` 우선.
 
-    Example 1:
-    event: OPEC production cut lifts oil prices
+    `event` 작성 기준:
+    - 한 줄, 30자 이내로 핵심 사건만 씁니다.
+
+    `facts` 작성 기준:
+    - 핵심 근거 1~2개만 짧게 한국어로. 수치가 있으면 반드시 포함. 50자 이내.
+
+    예시 1 — consumer_link: yes, cost_signal: up:
+    event: OPEC 감산 합의로 국제유가 상승
     cost_signal: up
     consumer_link: yes
-    facts: OPEC agreed output cuts; WTI rose about 5%
+    facts: OPEC 감산 합의; WTI 약 5% 상승
+    summary_ko: OPEC의 감산 합의로 국제유가가 약 5% 상승했습니다. 이는 국내 휘발유·경유 가격 인상으로 이어질 수 있습니다. 가정의 연료비 및 난방비 부담이 커질 전망입니다.
 
-    Example 2:
-    event: Utility company cuts household gas and power bills
+    예시 2 — consumer_link: yes, cost_signal: down:
+    event: 전력·가스 공급업체, 가정용 요금 인하
     cost_signal: down
     consumer_link: yes
-    facts: Annual gas bill cut 12%; electricity bill cut 5%
+    facts: 연간 가스비 12% 인하; 전기료 5% 인하
+    summary_ko: 전력·가스 공급업체가 가정용 요금을 인하했습니다. 연간 가스비는 12%, 전기료는 5% 줄어들 예정입니다. 가계의 공공요금 부담이 완화될 것으로 보입니다.
 
-    Example 3:
-    event: Central bank holds rates
+    예시 3 — consumer_link: yes, cost_signal: none (상승·하락 혼재):
+    event: 유가 상승과 정부 보조금 확대 동시 발생
+    cost_signal: none
+    consumer_link: yes
+    facts: 유가 4% 상승; 정부 유류세 인하 발표
+    summary_ko: 국제유가가 4% 올랐지만 정부가 동시에 유류세 인하를 발표했습니다. 가계 연료비에 대한 순 영향 방향이 불명확합니다. 추가 발표에 따라 부담 증감이 결정될 전망입니다.
+
+    예시 4 — consumer_link: no:
+    event: 중앙은행 기준금리 동결
     cost_signal: none
     consumer_link: no
-    facts: Policy rate unchanged; no direct household price change stated
+    facts: 정책금리 변동 없음; 가계 직접 가격 변화 없음
+    summary_ko:
     """
 ).strip()
 
 
 SUMMARY_USER_PROMPT = dedent(
     """
-    Summarize only the direct consumer-cost signal from this article.
+    다음 기사에서 소비자 생활비 영향 신호를 분류하고 한국어로 요약해주세요.
 
     {content}
     """

--- a/prd/llm/schemas.py
+++ b/prd/llm/schemas.py
@@ -32,6 +32,14 @@ class CausalEffect(BaseModel):
     change_pct_min: float | None = None
     change_pct_max: float | None = None
     monthly_impact: int | None = None
+    raw_shock_percent: float = 0.0
+    raw_shock_rationale: str = ""
+    transmission_time_months: int = 1
+    transmission_rationale: str = ""
+    wallet_hit_percent: float = 0.0
+    raw_shock_factors: list[str] = Field(default_factory=list)
+    wallet_hit_factors: list[str] = Field(default_factory=list)
+    logic_steps: list[dict] = Field(default_factory=list)
 
 
 class CausalResult(BaseModel):


### PR DESCRIPTION
## Summary
- LLM1(summary_prompt), LLM2(causal_prompt) 전체 한국어 재작성 및 summary_ko 필드 추가
- CausalEffect 8개 미사용 컬럼 활성화 (raw_shock_percent 등) 및 DB 저장 반영
- korea_relevance 정규화, factory/category_registry lazy import 수정

## Test plan
- [ ] main.py 실행 후 news_analyses.summary에 한국어 요약 저장 확인
- [ ] causal_chains 신규 컬럼(raw_shock_percent 등) 데이터 저장 확인
- [ ] Supabase 환경에서 psycopg 미설치 시 정상 실행 확인

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)