### PR TITLE
fix: schedule PRD batch execution (#54)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
 name: Run PRD Batch On EC2
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '0 0 * * *'  # KST 09:00
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- replace the PRD EC2 workflow main push trigger with a daily cron schedule
- keep manual execution available through workflow_dispatch
- leave the EC2 deployment steps unchanged

## Verification
- reviewed .github/workflows/deploy.yml trigger block
- did not run the workflow from GitHub Actions
