### PR TITLE
chore(backend): pin starlette<1.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.111.0
+starlette<1.0
 uvicorn[standard]>=0.29.0
 python-dotenv>=1.0.1
 psycopg[binary]>=3.1.0


### PR DESCRIPTION
## Summary
- Add \starlette<1.0\ to \ackend/requirements.txt\ to avoid Starlette 1.x breaking changes with the current FastAPI stack.

Closes #67

Made with [Cursor](https://cursor.com)