### PR TITLE
Preserve paginated API responses

### DIFF
--- a/front_web/src/lib/api.ts
+++ b/front_web/src/lib/api.ts
@@ -34,6 +34,7 @@ async function apiFetch(path: string, options: RequestInit = {}): Promise<Respon
 async function parseJson(res: Response) {
   const json = await res.json()
   if (!res.ok) throw new Error(json?.detail ?? json?.error ?? `HTTP ${res.status}`)
+  if (json && typeof json === 'object' && 'data' in json && 'total' in json) return json
   return json?.data ?? json
 }
 


### PR DESCRIPTION
## Summary
- Keep { data, total } API responses intact in the front_web API parser
- Fix list pages showing 0 rows after backend API migration

## Verification
- npm run build (front_web)
- python -m compileall backend
- npm test (front_web) unavailable: package.json has no test script

Closes #73