### PR TITLE
Remodel news management screen

### DIFF
--- a/backend/api/routes/news.py
+++ b/backend/api/routes/news.py
@@ -61,22 +61,50 @@ def list_raw_news(
 
 
 @router.get("/analyses")
-def list_analyses(page: int = 0, page_size: int = 50):
+def list_analyses(
+    page: int = 0,
+    page_size: int = 50,
+    search: str | None = None,
+    min_reliability: float | None = None,
+    time_horizon: str | None = None,
+    geo_scope: str | None = None,
+    korea_relevance: str | None = None,
+):
+    where = []
+    params: list[object] = []
+    if search:
+        where.append("summary ILIKE %s")
+        params.append(f"%{search}%")
+    if min_reliability is not None:
+        where.append("reliability >= %s")
+        params.append(min_reliability)
+    if time_horizon:
+        where.append("time_horizon = %s")
+        params.append(time_horizon)
+    if geo_scope:
+        where.append("geo_scope = %s")
+        params.append(geo_scope)
+    if korea_relevance:
+        where.append("korea_relevance = %s")
+        params.append(korea_relevance)
+
+    where_sql = f"WHERE {' AND '.join(where)}" if where else ""
     limit = max(1, min(page_size, 100))
     offset = max(0, page) * limit
     with get_conn() as conn:
         with conn.cursor() as cur:
-            cur.execute("SELECT COUNT(*) FROM news_analyses")
+            cur.execute(f"SELECT COUNT(*) FROM news_analyses {where_sql}", params)
             total = cur.fetchone()[0]
             cur.execute(
-                """
+                f"""
                 SELECT id, summary, reliability, time_horizon, geo_scope,
                        korea_relevance, created_at, effect_chain,
                        reliability_reason, raw_news_id
                 FROM news_analyses
+                {where_sql}
                 ORDER BY created_at DESC
                 LIMIT %s OFFSET %s
                 """,
-                (limit, offset),
+                [*params, limit, offset],
             )
             return {"data": _rows(cur), "total": total}

--- a/front_web/src/lib/api.ts
+++ b/front_web/src/lib/api.ts
@@ -78,8 +78,22 @@ export const newsApi = {
     date_to: filters.dateTo,
     show_deleted: filters.showDeleted,
   })}`).then(parseJson),
-  analyses: (page: number, pageSize: number) =>
-    apiFetch(`/api/v1/news/analyses${toQuery({ page, page_size: pageSize })}`).then(parseJson),
+  analyses: (page: number, pageSize: number, filters: {
+    search?: string
+    minReliability?: number
+    timeHorizon?: string
+    geoScope?: string
+    koreaRelevance?: string
+  } = {}) =>
+    apiFetch(`/api/v1/news/analyses${toQuery({
+      page,
+      page_size: pageSize,
+      search: filters.search,
+      min_reliability: filters.minReliability,
+      time_horizon: filters.timeHorizon,
+      geo_scope: filters.geoScope,
+      korea_relevance: filters.koreaRelevance,
+    })}`).then(parseJson),
 }
 
 export const causalApi = {

--- a/front_web/src/pages/NewsPage.tsx
+++ b/front_web/src/pages/NewsPage.tsx
@@ -1,168 +1,139 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { ExternalLink } from 'lucide-react'
+import { CalendarDays, Filter, Search, ShieldCheck } from 'lucide-react'
 import { newsApi } from '../lib/api'
-import { StatusBadge, ReliabilityBar } from '../components/ui/Badge'
+import { ReliabilityBar } from '../components/ui/Badge'
 import { Pagination } from '../components/ui/Pagination'
 import { Drawer } from '../components/ui/Drawer'
 import { formatDate } from '../lib/helpers'
-import { formatCategory } from '../constants/category'
-import { COLORS } from '../constants/colors'
 
 const PAGE_SIZE = 50
-const STATUSES = ['processed', 'skipped', 'pending', 'failed']
+const HORIZONS = ['short', 'medium', 'long']
+const GEO_SCOPES = ['korea', 'global', 'asia', 'other']
+const KOREA_RELEVANCE = ['direct', 'indirect', 'none']
 
-export function NewsPage() {
-  const [tab, setTab] = useState<'raw' | 'analyses'>('raw')
+type AnalysisRow = {
+  id: string
+  summary: string
+  reliability: number
+  time_horizon: string | null
+  geo_scope: string | null
+  korea_relevance: string | null
+  created_at: string
+  effect_chain?: string[]
+  reliability_reason?: string | null
+  raw_news_id?: string | null
+}
 
+function SelectFilter({
+  value,
+  onChange,
+  options,
+  placeholder,
+}: {
+  value: string
+  onChange: (value: string) => void
+  options: string[]
+  placeholder: string
+}) {
   return (
-    <div className="space-y-4">
-      <h1 className="text-xl font-bold text-gray-900">뉴스 관리</h1>
-      <div className="flex gap-1 border-b border-gray-200">
-        {(['raw', 'analyses'] as const).map(t => (
-          <button key={t} onClick={() => setTab(t)}
-            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${tab === t ? 'border-primary text-primary' : 'border-transparent text-gray-500 hover:text-gray-700'}`}>
-            {t === 'raw' ? '원본 뉴스' : '분석 결과'}
-          </button>
-        ))}
+    <select
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      className="h-9 rounded-lg border border-gray-200 bg-white px-3 text-xs text-gray-600 outline-none focus:border-primary"
+    >
+      <option value="">{placeholder}</option>
+      {options.map(option => (
+        <option key={option} value={option}>{option}</option>
+      ))}
+    </select>
+  )
+}
+
+function Metric({ label, value, icon: Icon }: { label: string; value: string; icon: typeof ShieldCheck }) {
+  return (
+    <div className="rounded-lg border border-gray-100 bg-white px-4 py-3">
+      <div className="flex items-center gap-2 text-xs text-gray-500">
+        <Icon size={14} />
+        <span>{label}</span>
       </div>
-      {tab === 'raw' ? <RawNewsTab /> : <AnalysesTab />}
+      <p className="mt-2 font-mono text-xl font-semibold text-gray-900">{value}</p>
     </div>
   )
 }
 
-function RawNewsTab() {
-  const [page, setPage]           = useState(0)
-  const [search, setSearch]       = useState('')
-  const [statuses, setStatuses]   = useState<string[]>([])
-  const [showDeleted, setDeleted] = useState(false)
-  const [selected, setSelected]   = useState<Record<string, unknown> | null>(null)
+export function NewsPage() {
+  const [page, setPage] = useState(0)
+  const [search, setSearch] = useState('')
+  const [minReliability, setMinReliability] = useState('')
+  const [timeHorizon, setTimeHorizon] = useState('')
+  const [geoScope, setGeoScope] = useState('')
+  const [koreaRelevance, setKoreaRelevance] = useState('')
+  const [selected, setSelected] = useState<AnalysisRow | null>(null)
 
-  const filters = { search, status: statuses, showDeleted }
-  useEffect(() => { setPage(0) }, [search, statuses, showDeleted])
+  const filters = {
+    search,
+    minReliability: minReliability ? Number(minReliability) : undefined,
+    timeHorizon,
+    geoScope,
+    koreaRelevance,
+  }
+
+  useEffect(() => { setPage(0) }, [search, minReliability, timeHorizon, geoScope, koreaRelevance])
 
   const { data, isLoading } = useQuery({
-    queryKey: ['rawNews', page, filters],
-    queryFn: () => newsApi.raw(page, PAGE_SIZE, filters),
+    queryKey: ['analyses', page, filters],
+    queryFn: () => newsApi.analyses(page, PAGE_SIZE, filters),
   })
-  const totalPages = Math.ceil((data?.total ?? 0) / PAGE_SIZE)
 
-  const toggleStatus = (s: string) =>
-    setStatuses(prev => prev.includes(s) ? prev.filter(x => x !== s) : [...prev, s])
+  const rows = (data?.data ?? []) as AnalysisRow[]
+  const total = data?.total ?? 0
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  const pageStats = useMemo(() => {
+    const avg = rows.length
+      ? Math.round(rows.reduce((sum, row) => sum + (row.reliability ?? 0), 0) / rows.length * 100)
+      : 0
+    const direct = rows.filter(row => row.korea_relevance === 'direct').length
+    const high = rows.filter(row => row.reliability >= 0.8).length
+    return { avg, direct, high }
+  }, [rows])
 
   return (
-    <>
-      {/* 필터 바 */}
-      <div className="flex flex-wrap gap-3 items-center rounded-xl bg-white p-3 border border-gray-100">
-        <input value={search} onChange={e => setSearch(e.target.value)}
-          placeholder="제목 검색..." className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm w-48 outline-none focus:border-primary" />
-        <div className="flex gap-2">
-          {STATUSES.map(s => (
-            <button key={s} onClick={() => toggleStatus(s)}
-              className={`px-2.5 py-1 text-xs rounded-full border transition-colors font-medium ${statuses.includes(s) ? 'bg-primary text-white border-primary' : 'border-gray-200 text-gray-500 hover:border-gray-300'}`}>
-              {s}
-            </button>
-          ))}
-        </div>
-        <label className="flex items-center gap-1.5 text-xs text-gray-500 cursor-pointer ml-auto">
-          <input type="checkbox" checked={showDeleted} onChange={e => setDeleted(e.target.checked)} className="rounded" />
-          삭제 항목 포함
-        </label>
-      </div>
-
-      <div className="rounded-xl bg-white border border-gray-100 overflow-hidden">
-        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-50">
-          <span className="font-mono text-xs text-gray-400">총 {(data?.total ?? 0).toLocaleString()}건</span>
-        </div>
-        {isLoading ? <div className="py-12 text-center text-sm text-gray-400">로딩 중...</div> : (
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 text-xs text-gray-500">
-              <tr>
-                <th className="px-4 py-2.5 text-left font-medium">제목</th>
-                <th className="px-4 py-2.5 text-left font-medium w-28">상태</th>
-                <th className="px-4 py-2.5 text-left font-medium w-32">키워드</th>
-                <th className="px-4 py-2.5 text-left font-medium w-24">발행일</th>
-                <th className="px-4 py-2.5 text-center font-medium w-16">재시도</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-50">
-              {(data?.data ?? []).map((row: Record<string, unknown>) => (
-                <tr key={row.id as string} onClick={() => setSelected(row)}
-                  className="hover:bg-gray-50 cursor-pointer transition-colors">
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      <p className="font-medium text-gray-800 line-clamp-1">{row.title as string}</p>
-                      {!!row.news_url && (
-                        <a href={row.news_url as string} target="_blank" rel="noopener noreferrer"
-                          onClick={e => e.stopPropagation()} className="text-gray-300 hover:text-primary shrink-0">
-                          <ExternalLink size={12} />
-                        </a>
-                      )}
-                    </div>
-                    <div className="flex gap-1 mt-1 flex-wrap">
-                      {((row.increased_items as string[]) ?? []).map(k => (
-                        <span key={k} className="text-[10px] px-1.5 py-0.5 rounded font-medium" style={{ backgroundColor: COLORS.tagUpBg, color: COLORS.tagUpText }}>▲{formatCategory(k)}</span>
-                      ))}
-                      {((row.decreased_items as string[]) ?? []).map(k => (
-                        <span key={k} className="text-[10px] px-1.5 py-0.5 rounded font-medium" style={{ backgroundColor: COLORS.tagDownBg, color: COLORS.tagDownText }}>▼{formatCategory(k)}</span>
-                      ))}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3"><StatusBadge status={row.processing_status as string} /></td>
-                  <td className="px-4 py-3">
-                    <div className="flex flex-wrap gap-1">
-                      {((row.keyword as string[]) ?? []).slice(0, 3).map(k => (
-                        <span key={k} className="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-500">{k}</span>
-                      ))}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 font-mono text-xs text-gray-400">{formatDate(row.origin_published_at as string)}</td>
-                  <td className="px-4 py-3 text-center font-mono text-xs text-gray-400">{row.retry_count as number}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-        <div className="px-4 pb-3">
-          <Pagination page={page} totalPages={totalPages} onChange={setPage} />
+    <div className="space-y-4">
+      <div className="flex items-end justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">뉴스 관리</h1>
+          <p className="mt-1 text-xs text-gray-500">분석된 뉴스와 신뢰도, 영향 경로를 관리합니다.</p>
         </div>
       </div>
 
-      <Drawer open={!!selected} onClose={() => setSelected(null)} title="뉴스 상세">
-        {selected && (
-          <div className="space-y-4 text-sm">
-            <p className="font-semibold text-gray-900">{selected.title as string}</p>
-            <StatusBadge status={selected.processing_status as string} />
-            <div className="space-y-1">
-              <p className="text-xs font-medium text-gray-500">URL</p>
-              <a href={selected.news_url as string} target="_blank" rel="noopener noreferrer" className="text-xs text-primary break-all">{selected.news_url as string}</a>
-            </div>
-            <div className="grid grid-cols-2 gap-3 font-mono text-xs text-gray-600">
-              <div><span className="text-gray-400">발행일</span><br />{formatDate(selected.origin_published_at as string)}</div>
-              <div><span className="text-gray-400">재시도</span><br />{selected.retry_count as number}회</div>
-            </div>
-          </div>
-        )}
-      </Drawer>
-    </>
-  )
-}
+      <div className="grid grid-cols-4 gap-3">
+        <Metric label="분석 뉴스" value={`${total.toLocaleString()}건`} icon={CalendarDays} />
+        <Metric label="현재 페이지 평균 신뢰도" value={`${pageStats.avg}%`} icon={ShieldCheck} />
+        <Metric label="한국 직접 관련" value={`${pageStats.direct.toLocaleString()}건`} icon={Filter} />
+        <Metric label="고신뢰 분석" value={`${pageStats.high.toLocaleString()}건`} icon={ShieldCheck} />
+      </div>
 
-function AnalysesTab() {
-  const [page, setPage]       = useState(0)
-  const [selected, setSelected] = useState<Record<string, unknown> | null>(null)
+      <div className="flex flex-wrap items-center gap-2 rounded-xl bg-white p-3 border border-gray-100">
+        <div className="relative">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="요약 검색..."
+            className="h-9 w-72 rounded-lg border border-gray-200 pl-9 pr-3 text-sm outline-none focus:border-primary"
+          />
+        </div>
+        <SelectFilter value={minReliability} onChange={setMinReliability} options={['0.8', '0.7', '0.5']} placeholder="신뢰도" />
+        <SelectFilter value={timeHorizon} onChange={setTimeHorizon} options={HORIZONS} placeholder="지평선" />
+        <SelectFilter value={geoScope} onChange={setGeoScope} options={GEO_SCOPES} placeholder="지역" />
+        <SelectFilter value={koreaRelevance} onChange={setKoreaRelevance} options={KOREA_RELEVANCE} placeholder="한국 관련" />
+      </div>
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['analyses', page],
-    queryFn: () => newsApi.analyses(page, PAGE_SIZE),
-  })
-  const totalPages = Math.ceil((data?.total ?? 0) / PAGE_SIZE)
-
-  return (
-    <>
       <div className="rounded-xl bg-white border border-gray-100 overflow-hidden">
         <div className="px-4 py-2.5 border-b border-gray-50">
-          <span className="font-mono text-xs text-gray-400">총 {(data?.total ?? 0).toLocaleString()}건</span>
+          <span className="font-mono text-xs text-gray-400">총 {total.toLocaleString()}건</span>
         </div>
         {isLoading ? <div className="py-12 text-center text-sm text-gray-400">로딩 중...</div> : (
           <table className="w-full text-sm">
@@ -170,25 +141,28 @@ function AnalysesTab() {
               <tr>
                 <th className="px-4 py-2.5 text-left font-medium">요약</th>
                 <th className="px-4 py-2.5 text-left font-medium w-28">신뢰도</th>
-                <th className="px-4 py-2.5 text-left font-medium w-20">지평선</th>
-                <th className="px-4 py-2.5 text-left font-medium w-20">지리</th>
-                <th className="px-4 py-2.5 text-left font-medium w-20">한국 관련</th>
+                <th className="px-4 py-2.5 text-left font-medium w-24">지평선</th>
+                <th className="px-4 py-2.5 text-left font-medium w-24">지역</th>
+                <th className="px-4 py-2.5 text-left font-medium w-24">한국 관련</th>
                 <th className="px-4 py-2.5 text-left font-medium w-28">분석일</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-50">
-              {(data?.data ?? []).map((row: Record<string, unknown>) => (
-                <tr key={row.id as string} onClick={() => setSelected(row)} className="hover:bg-gray-50 cursor-pointer transition-colors">
-                  <td className="px-4 py-3 max-w-xs">
-                    <p className="font-medium text-gray-800 line-clamp-2">{row.summary as string}</p>
+              {rows.map(row => (
+                <tr key={row.id} onClick={() => setSelected(row)} className="hover:bg-gray-50 cursor-pointer transition-colors">
+                  <td className="px-4 py-3 max-w-3xl">
+                    <p className="font-medium text-gray-800 line-clamp-2">{row.summary}</p>
                   </td>
-                  <td className="px-4 py-3"><ReliabilityBar value={row.reliability as number} /></td>
-                  <td className="px-4 py-3 font-mono text-xs text-gray-500">{row.time_horizon as string}</td>
-                  <td className="px-4 py-3 font-mono text-xs text-gray-500">{row.geo_scope as string}</td>
-                  <td className="px-4 py-3 font-mono text-xs text-gray-500">{row.korea_relevance as string}</td>
-                  <td className="px-4 py-3 font-mono text-xs text-gray-400">{formatDate(row.created_at as string)}</td>
+                  <td className="px-4 py-3"><ReliabilityBar value={row.reliability} /></td>
+                  <td className="px-4 py-3 font-mono text-xs text-gray-500">{row.time_horizon ?? '-'}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-gray-500">{row.geo_scope ?? '-'}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-gray-500">{row.korea_relevance ?? '-'}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-gray-400">{formatDate(row.created_at)}</td>
                 </tr>
               ))}
+              {!rows.length && (
+                <tr><td colSpan={6} className="py-12 text-center text-sm text-gray-400">분석 결과가 없습니다.</td></tr>
+              )}
             </tbody>
           </table>
         )}
@@ -200,33 +174,33 @@ function AnalysesTab() {
       <Drawer open={!!selected} onClose={() => setSelected(null)} title="분석 상세">
         {selected && (
           <div className="space-y-5 text-sm">
-            <p className="font-semibold text-gray-900">{selected.summary as string}</p>
-            <ReliabilityBar value={selected.reliability as number} />
+            <p className="font-semibold text-gray-900 leading-relaxed">{selected.summary}</p>
+            <ReliabilityBar value={selected.reliability} />
             <div>
-              <p className="text-xs font-medium text-gray-500 mb-1">신뢰도 이유</p>
-              <p className="text-xs text-gray-600">{selected.reliability_reason as string ?? '-'}</p>
+              <p className="text-xs font-medium text-gray-500 mb-1">신뢰도 근거</p>
+              <p className="text-xs text-gray-600 leading-relaxed">{selected.reliability_reason ?? '-'}</p>
             </div>
-            {Array.isArray(selected.effect_chain) && selected.effect_chain.length > 0 && (
+            {!!selected.effect_chain?.length && (
               <div>
-                <p className="text-xs font-medium text-gray-500 mb-2">인과 흐름</p>
+                <p className="text-xs font-medium text-gray-500 mb-2">영향 경로</p>
                 <div className="flex flex-wrap items-center gap-1 text-xs">
-                  {(selected.effect_chain as string[]).map((s, i) => (
-                    <span key={i} className="flex items-center gap-1">
-                      <span className="bg-surface px-2 py-1 rounded text-gray-700">{s}</span>
-                      {i < (selected.effect_chain as string[]).length - 1 && <span className="text-gray-300">→</span>}
+                  {selected.effect_chain.map((step, i) => (
+                    <span key={`${step}-${i}`} className="flex items-center gap-1">
+                      <span className="bg-surface px-2 py-1 rounded text-gray-700">{step}</span>
+                      {i < selected.effect_chain!.length - 1 && <span className="text-gray-300">→</span>}
                     </span>
                   ))}
                 </div>
               </div>
             )}
             <div className="grid grid-cols-3 gap-2 font-mono text-xs text-gray-600">
-              <div><span className="text-gray-400 block">지평선</span>{selected.time_horizon as string}</div>
-              <div><span className="text-gray-400 block">지리</span>{selected.geo_scope as string}</div>
-              <div><span className="text-gray-400 block">한국 관련</span>{selected.korea_relevance as string}</div>
+              <div><span className="text-gray-400 block">지평선</span>{selected.time_horizon ?? '-'}</div>
+              <div><span className="text-gray-400 block">지역</span>{selected.geo_scope ?? '-'}</div>
+              <div><span className="text-gray-400 block">한국 관련</span>{selected.korea_relevance ?? '-'}</div>
             </div>
           </div>
         )}
       </Drawer>
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Remove the raw news tab from the news management screen
- Rebuild news management around analyzed news results only
- Add backend filters for analysis search, reliability, horizon, geography, and Korea relevance
- Add summary metrics, filters, focused table, and detail drawer

## Verification
- API smoke checks for /api/v1/news/analyses filters
- python -m compileall backend
- npm run build (front_web)
- npm test (front_web) unavailable: package.json has no test script

Closes #75