### PR TITLE
Refactor dashboard metrics

### DIFF
--- a/backend/api/routes/dashboard.py
+++ b/backend/api/routes/dashboard.py
@@ -11,41 +11,30 @@ def _rows(cur) -> list[dict]:
     return [dict(zip(cols, r)) for r in cur.fetchall()]
 
 
+def _latest_metric(cur, table: str, value_col: str) -> list[dict]:
+    cur.execute(
+        f"""
+        SELECT {value_col}, reference_date
+        FROM {table}
+        WHERE {value_col} IS NOT NULL
+        ORDER BY reference_date::date DESC
+        LIMIT 2
+        """
+    )
+    return _rows(cur)
+
+
 @router.get("/kpi")
 def get_kpi_latest():
     with get_conn() as conn:
         with conn.cursor() as cur:
-            result = {}
-            queries = {
-                "gpr": """
-                    SELECT ai_gpr_index, reference_date
-                    FROM indicator_gpr_daily_logs
-                    ORDER BY reference_date DESC
-                    LIMIT 2
-                """,
-                "ecos": """
-                    SELECT krw_usd_rate, reference_date
-                    FROM indicator_ecos_daily_logs
-                    ORDER BY reference_date DESC
-                    LIMIT 2
-                """,
-                "fred": """
-                    SELECT fred_wti, fred_treasury_10y, reference_date
-                    FROM indicator_fred_daily_logs
-                    ORDER BY reference_date DESC
-                    LIMIT 2
-                """,
-                "kosis": """
-                    SELECT cpi_total, reference_date
-                    FROM indicator_kosis_monthly_logs
-                    ORDER BY reference_date DESC
-                    LIMIT 2
-                """,
+            return {
+                "global_risk": _latest_metric(cur, "indicator_gpr_daily_logs", "ai_gpr_index"),
+                "exchange_rate": _latest_metric(cur, "indicator_ecos_daily_logs", "krw_usd_rate"),
+                "wti": _latest_metric(cur, "indicator_fred_daily_logs", "fred_wti"),
+                "cpi": _latest_metric(cur, "indicator_kosis_monthly_logs", "cpi_total"),
+                "treasury_10y": _latest_metric(cur, "indicator_fred_daily_logs", "fred_treasury_10y"),
             }
-            for key, sql in queries.items():
-                cur.execute(sql)
-                result[key] = _rows(cur)
-            return result
 
 
 @router.get("/pipeline-stats")

--- a/front_web/src/lib/api.ts
+++ b/front_web/src/lib/api.ts
@@ -54,7 +54,6 @@ function toQuery(params: Record<string, unknown>) {
 
 export const dashboardApi = {
   kpi: () => apiFetch('/api/v1/dashboard/kpi').then(parseJson),
-  pipelineStats: () => apiFetch('/api/v1/dashboard/pipeline-stats').then(parseJson),
   gprTrend: (days = 30) =>
     apiFetch(`/api/v1/dashboard/gpr-trend${toQuery({ days })}`).then(parseJson),
   causalSummary: () => apiFetch('/api/v1/dashboard/causal-summary').then(parseJson),

--- a/front_web/src/pages/DashboardPage.tsx
+++ b/front_web/src/pages/DashboardPage.tsx
@@ -1,156 +1,175 @@
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, BarChart, Bar, CartesianGrid } from 'recharts'
+import { Bar, BarChart, CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 import { dashboardApi } from '../lib/api'
 import { formatCategory, DIRECTION_MAP } from '../constants/category'
 import { formatDate, formatNumber } from '../lib/helpers'
 import { ReliabilityBar } from '../components/ui/Badge'
 import { COLORS } from '../constants/colors'
 
-const PAGE_TITLE = '대시보드'
+type MetricRow = Record<string, number | string | null>
 
-function KpiCard({ label, value, prev, date, max, unit }: {
-  label: string; value: number | null; prev: number | null
-  date: string; max: number; unit?: string
+function trendText(value: number | null, prev: number | null) {
+  if (value == null || prev == null) return { label: '-', color: '#9CA3AF' }
+  const diff = value - prev
+  return {
+    label: `${diff > 0 ? '+' : ''}${diff.toFixed(1)}`,
+    color: diff >= 0 ? COLORS.up : COLORS.down,
+  }
+}
+
+function KpiCard({
+  label,
+  value,
+  prev,
+  date,
+  max,
+  unit,
+}: {
+  label: string
+  value: number | null
+  prev: number | null
+  date: string
+  max: number
+  unit?: string
 }) {
-  const diff = (value ?? 0) - (prev ?? 0)
   const pct = max > 0 ? Math.min(100, Math.max(4, ((value ?? 0) / max) * 100)) : 50
-  const gaugeColor = pct < 25 ? '#60A5FA' : pct < 50 ? '#FBBF24' : pct < 75 ? '#F97316' : '#EF4444'
-  const diffColor = diff > 0 ? COLORS.up : COLORS.down
+  const trend = trendText(value, prev)
 
   return (
-    <div className="relative rounded-xl bg-white p-5 shadow-sm border border-gray-100 animate-fade-in-up overflow-hidden">
-      <div className="absolute top-0 left-0 w-1 h-full bg-primary rounded-l-xl" />
-      <p className="text-xs font-medium text-gray-500 mb-1 ml-1">{label}</p>
-      <p className="font-mono text-2xl font-medium tabular-nums text-gray-900 ml-1">
+    <div className="rounded-lg bg-white p-4 border border-gray-100">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-xs font-medium text-gray-500">{label}</p>
+        <span className="font-mono text-[10px] text-gray-400">{date || '-'}</span>
+      </div>
+      <p className="mt-2 font-mono text-2xl font-semibold tabular-nums text-gray-900">
         {value != null ? formatNumber(value) : '-'}
-        {unit && <span className="text-sm text-gray-400 ml-1">{unit}</span>}
+        {unit && <span className="ml-1 text-sm text-gray-400">{unit}</span>}
       </p>
-      <div className="my-2 h-1.5 rounded-full bg-gray-100 overflow-hidden ml-1">
-        <div className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: gaugeColor }} />
+      <div className="mt-3 h-1.5 rounded-full bg-gray-100 overflow-hidden">
+        <div className="h-full rounded-full bg-primary" style={{ width: `${pct}%` }} />
       </div>
-      <div className="flex items-center justify-between ml-1">
-        <span className="font-mono text-xs" style={{ color: diffColor }}>
-          {diff > 0 ? '▲' : '▼'}{Math.abs(diff).toFixed(1)}
-        </span>
-        <span className="font-mono text-[10px] text-gray-400">{date}</span>
-      </div>
+      <p className="mt-2 font-mono text-xs" style={{ color: trend.color }}>{trend.label}</p>
     </div>
   )
 }
 
-const PIPE_COLORS: Record<string, string> = {
-  processed: '#1D9E75', skipped: '#9CA3AF', pending: '#EF9F27', failed: '#D85A30',
+function first(rows: MetricRow[] | undefined, key: string) {
+  return (rows?.[0]?.[key] as number | null | undefined) ?? null
+}
+
+function second(rows: MetricRow[] | undefined, key: string) {
+  return (rows?.[1]?.[key] as number | null | undefined) ?? null
+}
+
+function dateOf(rows: MetricRow[] | undefined) {
+  return (rows?.[0]?.reference_date as string | undefined) ?? ''
 }
 
 export function DashboardPage() {
-  const { data: kpi }      = useQuery({ queryKey: ['kpi'],      queryFn: dashboardApi.kpi })
-  const { data: pipe }     = useQuery({ queryKey: ['pipeline'], queryFn: dashboardApi.pipelineStats })
-  const { data: gprTrend } = useQuery({ queryKey: ['gprTrend'], queryFn: () => dashboardApi.gprTrend(30) })
-  const { data: causal }   = useQuery({ queryKey: ['causalSum'],queryFn: dashboardApi.causalSummary })
-  const { data: news }     = useQuery({ queryKey: ['recentNews'],queryFn: () => dashboardApi.recentAnalyses(5) })
+  const { data: kpi } = useQuery({ queryKey: ['kpi'], queryFn: dashboardApi.kpi })
+  const { data: riskTrend } = useQuery({ queryKey: ['globalRiskTrend'], queryFn: () => dashboardApi.gprTrend(30) })
+  const { data: causal } = useQuery({ queryKey: ['causalSum'], queryFn: dashboardApi.causalSummary })
+  const { data: news } = useQuery({ queryKey: ['recentNews'], queryFn: () => dashboardApi.recentAnalyses(6) })
 
-  const g0 = kpi?.gpr[0]; const g1 = kpi?.gpr[1]
-  const e0 = kpi?.ecos[0]; const e1 = kpi?.ecos[1]
-  const f0 = kpi?.fred[0]; const f1 = kpi?.fred[1]
-  const k0 = kpi?.kosis[0]; const k1 = kpi?.kosis[1]
-
-  const pipeData = pipe ? Object.entries(pipe as Record<string, number>).map(([name, value]) => ({ name, value })) : []
-
-  const causalGrouped = Object.values(
-    ((causal ?? []) as Record<string, unknown>[]).reduce((acc: Record<string, { category: string; up: number; down: number; neutral: number }>, c) => {
-      const cat = c.category as string
-      if (!acc[cat]) acc[cat] = { category: cat, up: 0, down: 0, neutral: 0 }
-      const dir = (c.direction as string) ?? 'neutral'
-      if (dir in acc[cat]) acc[cat][dir as 'up' | 'down' | 'neutral']++
+  const causalGrouped = useMemo(() => Object.values(
+    ((causal ?? []) as Record<string, unknown>[]).reduce((acc: Record<string, { category: string; up: number; down: number; neutral: number }>, row) => {
+      const category = row.category as string
+      if (!acc[category]) acc[category] = { category, up: 0, down: 0, neutral: 0 }
+      const direction = (row.direction as string) ?? 'neutral'
+      if (direction in acc[category]) acc[category][direction as 'up' | 'down' | 'neutral'] += 1
       return acc
     }, {})
-  ).sort((a: { up: number; down: number }, b: { up: number; down: number }) => (b.up + b.down) - (a.up + a.down)).slice(0, 8)
+  ).sort((a, b) => (b.up + b.down) - (a.up + a.down)).slice(0, 8), [causal])
+
+  const highReliabilityCount = ((news ?? []) as Record<string, unknown>[]).filter(item => (item.reliability as number) >= 0.8).length
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-bold text-gray-900">{PAGE_TITLE}</h1>
-
-      {/* KPI 카드 */}
-      <div className="grid grid-cols-5 gap-4">
-        <KpiCard label="글로벌 위기 지수" value={g0?.ai_gpr_index ?? null} prev={g1?.ai_gpr_index ?? null} date={g0?.reference_date ?? ''} max={300} />
-        <KpiCard label="원/달러 환율" value={e0?.krw_usd_rate ?? null} prev={e1?.krw_usd_rate ?? null} date={e0?.reference_date ?? ''} max={2000} unit="₩" />
-        <KpiCard label="WTI 원유" value={f0?.fred_wti ?? null} prev={f1?.fred_wti ?? null} date={f0?.reference_date ?? ''} max={150} unit="$" />
-        <KpiCard label="한국 소비자물가" value={k0?.cpi_total ?? null} prev={k1?.cpi_total ?? null} date={k0?.reference_date ?? ''} max={10} unit="%" />
-        <KpiCard label="미 10년 국채" value={f0?.fred_treasury_10y ?? null} prev={f1?.fred_treasury_10y ?? null} date={f0?.reference_date ?? ''} max={8} unit="%" />
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-xl font-bold text-gray-900">대시보드</h1>
+        <p className="mt-1 text-xs text-gray-500">핵심 위험 지표와 최신 분석 흐름을 한 번에 확인합니다.</p>
       </div>
 
-      {/* 파이프라인 + GPR 추이 */}
-      <div className="grid grid-cols-2 gap-4">
-        <div className="rounded-xl bg-white p-5 shadow-sm border border-gray-100">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">뉴스 파이프라인 현황</p>
-          <div className="flex items-center gap-6">
-            <ResponsiveContainer width={140} height={140}>
-              <PieChart>
-                <Pie data={pipeData} cx="50%" cy="50%" innerRadius={40} outerRadius={65} dataKey="value" paddingAngle={2}>
-                  {pipeData.map(entry => (
-                    <Cell key={entry.name} fill={PIPE_COLORS[entry.name] ?? '#E5E7EB'} />
-                  ))}
-                </Pie>
-              </PieChart>
-            </ResponsiveContainer>
-            <div className="space-y-2">
-              {pipeData.map(({ name, value }) => (
-                <div key={name} className="flex items-center gap-2">
-                  <span className="inline-block h-2.5 w-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: PIPE_COLORS[name] ?? '#E5E7EB' }} />
-                  <span className="text-xs text-gray-600 w-16">{name}</span>
-                  <span className="font-mono text-xs font-medium tabular-nums text-gray-900">{value.toLocaleString()}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
+      <div className="grid grid-cols-5 gap-3">
+        <KpiCard label="글로벌 위험지수" value={first(kpi?.global_risk, 'ai_gpr_index')} prev={second(kpi?.global_risk, 'ai_gpr_index')} date={dateOf(kpi?.global_risk)} max={300} />
+        <KpiCard label="원/달러 환율" value={first(kpi?.exchange_rate, 'krw_usd_rate')} prev={second(kpi?.exchange_rate, 'krw_usd_rate')} date={dateOf(kpi?.exchange_rate)} max={2000} unit="원" />
+        <KpiCard label="WTI 원유" value={first(kpi?.wti, 'fred_wti')} prev={second(kpi?.wti, 'fred_wti')} date={dateOf(kpi?.wti)} max={150} unit="$" />
+        <KpiCard label="한국 소비자물가" value={first(kpi?.cpi, 'cpi_total')} prev={second(kpi?.cpi, 'cpi_total')} date={dateOf(kpi?.cpi)} max={10} unit="%" />
+        <KpiCard label="미 10년 국채" value={first(kpi?.treasury_10y, 'fred_treasury_10y')} prev={second(kpi?.treasury_10y, 'fred_treasury_10y')} date={dateOf(kpi?.treasury_10y)} max={8} unit="%" />
+      </div>
 
-        <div className="rounded-xl bg-white p-5 shadow-sm border border-gray-100">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">GPR 지수 30일 추이</p>
-          <ResponsiveContainer width="100%" height={130}>
-            <LineChart data={gprTrend ?? []}>
+      <div className="grid grid-cols-[1.1fr_0.9fr] gap-4">
+        <div className="rounded-lg bg-white p-5 border border-gray-100">
+          <div className="mb-4 flex items-center justify-between">
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">글로벌 위험지수 30일 추이</p>
+            <span className="text-xs text-gray-400">{(riskTrend ?? []).length.toLocaleString()} points</span>
+          </div>
+          <ResponsiveContainer width="100%" height={220}>
+            <LineChart data={riskTrend ?? []}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#F3F4F6" />
               <XAxis dataKey="reference_date" tick={{ fontSize: 9, fontFamily: 'DM Mono' }} tickFormatter={v => v.slice(5)} />
-              <YAxis tick={{ fontSize: 9, fontFamily: 'DM Mono' }} width={35} />
+              <YAxis tick={{ fontSize: 9, fontFamily: 'DM Mono' }} width={40} />
               <Tooltip contentStyle={{ fontSize: 11, fontFamily: 'DM Mono' }} />
               <Line type="monotone" dataKey="ai_gpr_index" stroke={COLORS.primary} strokeWidth={2} dot={false} />
             </LineChart>
           </ResponsiveContainer>
         </div>
+
+        <div className="rounded-lg bg-white p-5 border border-gray-100">
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">분석 품질</p>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="rounded-lg bg-surface p-4">
+              <p className="text-xs text-gray-500">최신 분석</p>
+              <p className="mt-2 font-mono text-2xl font-semibold text-gray-900">{((news ?? []) as unknown[]).length}</p>
+            </div>
+            <div className="rounded-lg bg-surface p-4">
+              <p className="text-xs text-gray-500">고신뢰 분석</p>
+              <p className="mt-2 font-mono text-2xl font-semibold text-gray-900">{highReliabilityCount}</p>
+            </div>
+          </div>
+          <div className="mt-4 space-y-3">
+            {((news ?? []) as Record<string, unknown>[]).slice(0, 3).map(item => (
+              <div key={item.id as string} className="border-t border-gray-100 pt-3 first:border-t-0 first:pt-0">
+                <p className="line-clamp-2 text-xs font-medium text-gray-800">{item.summary as string}</p>
+                <div className="mt-2 flex items-center justify-between">
+                  <span className="font-mono text-[10px] text-gray-400">{formatDate(item.created_at as string)}</span>
+                  <ReliabilityBar value={item.reliability as number} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
 
-      {/* 카테고리별 인과관계 + 최신 뉴스 */}
-      <div className="grid grid-cols-2 gap-4">
-        <div className="rounded-xl bg-white p-5 shadow-sm border border-gray-100">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">카테고리별 인과관계</p>
-          <ResponsiveContainer width="100%" height={220}>
-            <BarChart layout="vertical" data={causalGrouped} margin={{ left: 20 }}>
+      <div className="grid grid-cols-[0.95fr_1.05fr] gap-4">
+        <div className="rounded-lg bg-white p-5 border border-gray-100">
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">카테고리별 영향 방향</p>
+          <ResponsiveContainer width="100%" height={260}>
+            <BarChart layout="vertical" data={causalGrouped} margin={{ left: 16 }}>
               <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#F3F4F6" />
               <XAxis type="number" tick={{ fontSize: 9, fontFamily: 'DM Mono' }} />
               <YAxis type="category" dataKey="category" tickFormatter={formatCategory} tick={{ fontSize: 10 }} width={80} />
               <Tooltip contentStyle={{ fontSize: 11, fontFamily: 'DM Mono' }} />
-              <Bar dataKey="up"      stackId="a" fill={COLORS.up}      radius={[0,3,3,0]} />
-              <Bar dataKey="down"    stackId="a" fill={COLORS.down}    />
+              <Bar dataKey="up" stackId="a" fill={COLORS.up} radius={[0, 3, 3, 0]} />
+              <Bar dataKey="down" stackId="a" fill={COLORS.down} />
               <Bar dataKey="neutral" stackId="a" fill={COLORS.neutral} />
             </BarChart>
           </ResponsiveContainer>
         </div>
 
-        <div className="rounded-xl bg-white p-5 shadow-sm border border-gray-100">
+        <div className="rounded-lg bg-white p-5 border border-gray-100">
           <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">최신 분석 뉴스</p>
           <ul className="space-y-3">
-            {(news ?? []).map((item: Record<string, unknown>, i: number) => {
-              const chains = item.causal_chains as { direction?: string }[] ?? []
-              const dir = chains[0]?.direction ?? 'neutral'
-              const dirStyle = DIRECTION_MAP[dir]
+            {((news ?? []) as Record<string, unknown>[]).map(item => {
+              const chains = (item.causal_chains as { direction?: string }[]) ?? []
+              const direction = chains[0]?.direction ?? 'neutral'
+              const directionStyle = DIRECTION_MAP[direction]
               return (
-                <li key={item.id as string} className="animate-fade-in-up border-b border-gray-50 pb-3 last:border-0 last:pb-0" style={{ animationDelay: `${i * 60}ms` }}>
+                <li key={item.id as string} className="border-b border-gray-50 pb-3 last:border-0 last:pb-0">
                   <div className="flex items-start gap-2">
-                    <span className="mt-0.5 text-xs font-bold" style={{ color: dirStyle?.color }}>{dirStyle?.label.split(' ')[0]}</span>
+                    <span className="mt-0.5 text-xs font-bold" style={{ color: directionStyle?.color }}>{directionStyle?.label.split(' ')[0]}</span>
                     <p className="flex-1 text-xs font-medium text-gray-800 line-clamp-2">{item.summary as string}</p>
-                  </div>
-                  <div className="flex items-center justify-between mt-1 pl-4">
-                    <span className="font-mono text-[10px] text-gray-400">{formatDate((item.created_at as string) ?? '')}</span>
-                    <ReliabilityBar value={item.reliability as number} />
                   </div>
                 </li>
               )

--- a/front_web/src/pages/IndicatorPage.tsx
+++ b/front_web/src/pages/IndicatorPage.tsx
@@ -45,7 +45,7 @@ function GprTab({ period }: { period: Period }) {
   })
 
   return (
-    <ChartCard title="글로벌 위기 지수 (GPR)">
+    <ChartCard title="글로벌 위험지수">
       {isLoading ? <div className="h-48 flex items-center justify-center text-sm text-gray-400">로딩 중...</div> : (
         <ResponsiveContainer width="100%" height={220}>
           <LineChart data={data ?? []}>
@@ -54,8 +54,8 @@ function GprTab({ period }: { period: Period }) {
             <YAxis tick={{ fontSize: 9, fontFamily: 'DM Mono' }} width={40} />
             <Tooltip contentStyle={{ fontSize: 11, fontFamily: 'DM Mono' }} />
             <Legend wrapperStyle={{ fontSize: 11 }} />
-            <Line type="monotone" dataKey="ai_gpr_index" name="AI GPR" stroke={COLORS.primary} strokeWidth={2} dot={false} />
-            <Line type="monotone" dataKey="gpr_original" name="GPR" stroke={COLORS.neutral} strokeWidth={1.5} dot={false} strokeDasharray="4 2" />
+            <Line type="monotone" dataKey="ai_gpr_index" name="글로벌 위험지수" stroke={COLORS.primary} strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="gpr_original" name="기존 위험지수" stroke={COLORS.neutral} strokeWidth={1.5} dot={false} strokeDasharray="4 2" />
           </LineChart>
         </ResponsiveContainer>
       )}
@@ -161,7 +161,7 @@ function KosisTab({ period }: { period: Period }) {
 
 type Tab = 'gpr' | 'ecos' | 'fred' | 'kosis'
 const TABS: { key: Tab; label: string }[] = [
-  { key: 'gpr', label: 'GPR 위기지수' },
+  { key: 'gpr', label: '글로벌 위험지수' },
   { key: 'ecos', label: '원화 환율' },
   { key: 'fred', label: 'FRED 원자재/금리' },
   { key: 'kosis', label: '한국 CPI' },


### PR DESCRIPTION
## Summary
- Remove the dashboard news pipeline chart from the UI
- Rename visible GPR labels to 글로벌 위험지수
- Fix WTI KPI by selecting latest non-null metric rows per KPI
- Refactor dashboard into focused KPI, risk trend, analysis quality, category impact, and recent analysis sections

## Verification
- Dashboard KPI API smoke check confirms WTI returns 91.06 on 2026-04-20
- npm run build (front_web)
- python -m compileall backend
- npm test (front_web) unavailable: package.json has no test script
- rg check for old GPR labels and pipeline chart references

Closes #77