### PR TITLE
feat: 오늘의 물가 브리핑 기능 (LLM3 + 공개 페이지)

### DIFF
--- a/backend/api/routes/briefing.py
+++ b/backend/api/routes/briefing.py
@@ -1,0 +1,56 @@
+from datetime import date
+
+from fastapi import APIRouter
+
+from db import get_conn
+
+router = APIRouter()
+
+
+def _rows(cur) -> list[dict]:
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, r)) for r in cur.fetchall()]
+
+
+@router.get("/today")
+def get_today_briefing():
+    today = date.today().isoformat()
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            try:
+                cur.execute(
+                    """
+                    SELECT id, briefing_date, headline, overview, items,
+                           overall_risk, consumer_tip, indicators, source_count, created_at
+                    FROM daily_briefings
+                    WHERE briefing_date <= %s
+                    ORDER BY briefing_date DESC
+                    LIMIT 1
+                    """,
+                    [today],
+                )
+                rows = _rows(cur)
+            except Exception:
+                return {"data": None}
+    return {"data": rows[0] if rows else None}
+
+
+@router.get("/history")
+def get_briefing_history(days: int = 7):
+    days = max(1, min(days, 30))
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            try:
+                cur.execute(
+                    """
+                    SELECT id, briefing_date, headline, overall_risk, source_count, created_at
+                    FROM daily_briefings
+                    ORDER BY briefing_date DESC
+                    LIMIT %s
+                    """,
+                    [days],
+                )
+                rows = _rows(cur)
+            except Exception:
+                return {"data": []}
+    return {"data": rows}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from config import get_cors_allow_origins
-from api.routes import category, causal, consumer_item, dashboard, indicators, news
+from api.routes import briefing, category, causal, consumer_item, dashboard, indicators, news
 
 app = FastAPI(title="Costview API", version="1.0.0")
 
@@ -19,6 +19,7 @@ app.include_router(dashboard.router,     prefix="/api/v1/dashboard")
 app.include_router(indicators.router,    prefix="/api/v1/indicators")
 app.include_router(news.router,          prefix="/api/v1/news")
 app.include_router(causal.router,        prefix="/api/v1/causal")
+app.include_router(briefing.router,      prefix="/api/v1/briefing")
 
 
 @app.get("/")

--- a/backend/migrations/001_daily_briefings.sql
+++ b/backend/migrations/001_daily_briefings.sql
@@ -1,0 +1,25 @@
+-- daily_briefings: 일별 물가 브리핑 저장 테이블
+-- LLM3(briefing_main.py)가 매일 upsert, 백엔드 /api/v1/briefing/today가 공개 조회
+
+CREATE TABLE IF NOT EXISTS daily_briefings (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    briefing_date   date NOT NULL,
+    headline        text NOT NULL,
+    overview        text NOT NULL DEFAULT '',
+    items           jsonb NOT NULL DEFAULT '[]',
+    overall_risk    text NOT NULL DEFAULT 'medium'
+                        CHECK (overall_risk IN ('low', 'medium', 'high')),
+    consumer_tip    text,
+    indicators      jsonb,
+    source_count    int NOT NULL DEFAULT 0,
+    created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS daily_briefings_date_idx
+    ON daily_briefings (briefing_date);
+
+-- 공개 조회 허용 (RLS 없이 anon 읽기)
+ALTER TABLE daily_briefings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "public read" ON daily_briefings
+    FOR SELECT USING (true);

--- a/front_web/src/app/router.tsx
+++ b/front_web/src/app/router.tsx
@@ -8,9 +8,11 @@ import { CausalPage } from '../pages/CausalPage'
 import { IndicatorPage } from '../pages/IndicatorPage'
 import { CategoryPage } from '../pages/CategoryPage'
 import { ConsumerItemPage } from '../pages/ConsumerItemPage'
+import { BriefingPage } from '../pages/BriefingPage'
 
 export const router = createBrowserRouter([
   { path: '/login', element: <LoginPage /> },
+  { path: '/briefing', element: <BriefingPage /> },
   {
     element: <RequireAuth />,
     children: [{

--- a/front_web/src/components/layout/Sidebar.tsx
+++ b/front_web/src/components/layout/Sidebar.tsx
@@ -1,9 +1,10 @@
 import { NavLink } from 'react-router-dom'
-import { LayoutDashboard, Newspaper, GitBranch, BarChart2, Tag, ShoppingBag } from 'lucide-react'
+import { LayoutDashboard, Newspaper, GitBranch, BarChart2, Tag, ShoppingBag, BookOpen } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 
 const NAV = [
   { to: '/',           icon: LayoutDashboard, label: '대시보드' },
+  { to: '/briefing',   icon: BookOpen,        label: '오늘의 물가 브리핑' },
   { to: '/news',       icon: Newspaper,       label: '뉴스 관리' },
   { to: '/causal',     icon: GitBranch,       label: '물가 영향 분석' },
   { to: '/indicators', icon: BarChart2,       label: '경제 지표' },

--- a/front_web/src/lib/api.ts
+++ b/front_web/src/lib/api.ts
@@ -127,6 +127,11 @@ export const categoryApi = {
     apiFetch(`/api/v1/categories/${code}`, { method: 'DELETE' }).then(parseJson),
 }
 
+export const briefingApi = {
+  today: () => fetch(`${BASE}/api/v1/briefing/today`).then(r => r.json()).then(j => j?.data ?? null),
+  history: (days = 7) => fetch(`${BASE}/api/v1/briefing/history?days=${days}`).then(r => r.json()).then(j => j?.data ?? []),
+}
+
 export const consumerItemApi = {
   list: (showDeleted = false) =>
     apiFetch(`/api/v1/consumer-items/${toQuery({ show_deleted: showDeleted })}`).then(parseJson),

--- a/front_web/src/pages/BriefingPage.tsx
+++ b/front_web/src/pages/BriefingPage.tsx
@@ -1,0 +1,142 @@
+import { useQuery } from '@tanstack/react-query'
+import { TrendingUp, TrendingDown, Minus, AlertTriangle, Lightbulb, RefreshCw } from 'lucide-react'
+import { briefingApi } from '../lib/api'
+import { formatDate } from '../lib/helpers'
+
+type BriefingItem = {
+  category_ko: string
+  direction: 'up' | 'down' | 'neutral'
+  summary: string
+  reason: string
+}
+
+type Briefing = {
+  id: string
+  briefing_date: string
+  headline: string
+  overview: string
+  items: BriefingItem[]
+  overall_risk: 'low' | 'medium' | 'high'
+  consumer_tip: string | null
+  source_count: number
+  created_at: string
+}
+
+const RISK_CONFIG = {
+  low:    { label: '안정',     bg: 'bg-green-50',  text: 'text-green-700',  border: 'border-green-200' },
+  medium: { label: '주의',     bg: 'bg-amber-50',  text: 'text-amber-700',  border: 'border-amber-200' },
+  high:   { label: '위험',     bg: 'bg-red-50',    text: 'text-red-700',    border: 'border-red-200' },
+}
+
+const DIRECTION_CONFIG = {
+  up:      { Icon: TrendingUp,   color: 'text-red-500',   bg: 'bg-red-50',   label: '상승' },
+  down:    { Icon: TrendingDown, color: 'text-green-500', bg: 'bg-green-50', label: '하락' },
+  neutral: { Icon: Minus,        color: 'text-gray-400',  bg: 'bg-gray-50',  label: '변동없음' },
+}
+
+function RiskBadge({ risk }: { risk: 'low' | 'medium' | 'high' }) {
+  const cfg = RISK_CONFIG[risk] ?? RISK_CONFIG.medium
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold ${cfg.bg} ${cfg.text} ${cfg.border}`}>
+      <AlertTriangle size={11} />
+      물가 부담 {cfg.label}
+    </span>
+  )
+}
+
+function DirectionItem({ item }: { item: BriefingItem }) {
+  const cfg = DIRECTION_CONFIG[item.direction] ?? DIRECTION_CONFIG.neutral
+  const { Icon } = cfg
+  return (
+    <div className={`flex items-start gap-3 rounded-xl p-4 ${cfg.bg}`}>
+      <div className={`mt-0.5 flex-shrink-0 ${cfg.color}`}>
+        <Icon size={18} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-xs font-semibold text-gray-500">{item.category_ko}</span>
+          <span className={`text-xs font-medium ${cfg.color}`}>{cfg.label}</span>
+        </div>
+        <p className="text-sm font-semibold text-gray-800 mb-1">{item.summary}</p>
+        <p className="text-xs text-gray-500 leading-relaxed">{item.reason}</p>
+      </div>
+    </div>
+  )
+}
+
+function EmptyBriefing() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface">
+        <RefreshCw size={24} className="text-primary" />
+      </div>
+      <p className="text-base font-semibold text-gray-600">오늘 브리핑이 아직 준비되지 않았어요</p>
+      <p className="mt-2 text-sm text-gray-400">매일 오전 브리핑이 자동으로 생성됩니다.</p>
+    </div>
+  )
+}
+
+export function BriefingPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['briefing', 'today'],
+    queryFn: briefingApi.today,
+  })
+
+  const briefing = data as Briefing | null
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-5">
+      <div className="flex items-end justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">오늘의 물가 브리핑</h1>
+          <p className="mt-1 text-xs text-gray-500">AI가 오늘 뉴스를 분석해 장바구니에 미칠 영향을 알려드립니다.</p>
+        </div>
+        {briefing && (
+          <span className="font-mono text-xs text-gray-400">{briefing.briefing_date}</span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="py-20 flex items-center justify-center gap-2 text-sm text-gray-400">
+          <div className="spinner" /> 브리핑 불러오는 중...
+        </div>
+      ) : !briefing ? (
+        <EmptyBriefing />
+      ) : (
+        <>
+          <div className="rounded-2xl bg-white border border-gray-100 shadow-sm p-6 space-y-3 animate-fade-in-up">
+            <div className="flex items-center justify-between">
+              <RiskBadge risk={briefing.overall_risk} />
+              <span className="text-xs text-gray-400">분석 뉴스 {briefing.source_count}건</span>
+            </div>
+            <h2 className="text-lg font-bold text-gray-900 leading-snug">{briefing.headline}</h2>
+            <p className="text-sm text-gray-600 leading-relaxed">{briefing.overview}</p>
+          </div>
+
+          {briefing.items.length > 0 && (
+            <div className="space-y-2 animate-fade-in-up [animation-delay:80ms]">
+              <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider px-1">품목별 영향</p>
+              {briefing.items.map((item, i) => (
+                <DirectionItem key={`${item.category_ko}-${i}`} item={item} />
+              ))}
+            </div>
+          )}
+
+          {briefing.consumer_tip && (
+            <div className="flex items-start gap-3 rounded-xl bg-surface border border-primary-accent p-4 animate-fade-in-up [animation-delay:160ms]">
+              <Lightbulb size={16} className="mt-0.5 flex-shrink-0 text-primary" />
+              <div>
+                <p className="text-xs font-semibold text-primary mb-1">오늘의 생활 팁</p>
+                <p className="text-sm text-gray-700">{briefing.consumer_tip}</p>
+              </div>
+            </div>
+          )}
+
+          <p className="text-center text-[11px] text-gray-300 animate-fade-in-up [animation-delay:240ms]">
+            {formatDate(briefing.created_at)} 기준 · AI 분석 결과이며 실제 가격과 다를 수 있습니다
+          </p>
+        </>
+      )}
+    </div>
+  )
+}

--- a/front_web/src/pages/CausalPage.tsx
+++ b/front_web/src/pages/CausalPage.tsx
@@ -151,7 +151,7 @@ export function CausalPage() {
               <XAxis dataKey="month" tick={{ fontSize: 9, fontFamily: 'DM Mono' }} />
               <YAxis tick={{ fontSize: 9, fontFamily: 'DM Mono' }} />
               <Tooltip contentStyle={{ fontSize: 10 }} />
-              <Bar dataKey="count" fill={COLORS.seafoam} radius={[3,3,0,0]} />
+              <Bar dataKey="count" fill={COLORS.series3} radius={[3,3,0,0]} />
             </BarChart>
           </ResponsiveContainer>
         </div>

--- a/prd/briefing_main.py
+++ b/prd/briefing_main.py
@@ -1,0 +1,155 @@
+"""
+일별 물가 브리핑 생성 엔트리포인트
+====================================
+오늘 분석된 news_analyses + causal_chains를 집계하여
+Gemini LLM3로 일반 소비자용 브리핑을 생성하고
+daily_briefings 테이블에 저장합니다.
+
+실행:
+  python -m prd.briefing_main
+  python -m prd.briefing_main --date 2025-01-15
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from prd.config import load_environment
+from prd.db.supabase_client import create_sb
+from prd.llm.chains.briefing_runner import run_briefing_chain
+
+
+def _log(msg: str) -> None:
+    print(f"[briefing] {msg}")
+
+
+def _fetch_today_analyses(sb, briefing_date: str) -> list[dict]:
+    date_from = (date.fromisoformat(briefing_date) - timedelta(days=1)).isoformat()
+    rows = (
+        sb.table("news_analyses")
+        .select("id, summary, reliability, effect_chain, time_horizon, korea_relevance")
+        .gte("created_at", date_from)
+        .lte("created_at", briefing_date + "T23:59:59")
+        .gte("reliability", 0.6)
+        .order("reliability", desc=True)
+        .limit(20)
+        .execute()
+    ).data or []
+    return rows
+
+
+def _fetch_today_causal(sb, briefing_date: str) -> list[dict]:
+    date_from = (date.fromisoformat(briefing_date) - timedelta(days=1)).isoformat()
+    rows = (
+        sb.table("causal_chains")
+        .select("category, category_ko, direction, magnitude")
+        .gte("created_at", date_from)
+        .lte("created_at", briefing_date + "T23:59:59")
+        .execute()
+    ).data or []
+    return rows
+
+
+def _fetch_latest_indicators(sb) -> dict:
+    try:
+        ecos = (
+            sb.table("indicator_ecos_daily_logs")
+            .select("krw_usd_rate, reference_date")
+            .order("reference_date", desc=True)
+            .limit(1)
+            .execute()
+        ).data or []
+        fred = (
+            sb.table("indicator_fred_daily_logs")
+            .select("fred_wti, reference_date")
+            .order("reference_date", desc=True)
+            .limit(1)
+            .execute()
+        ).data or []
+        kosis = (
+            sb.table("indicator_kosis_monthly_logs")
+            .select("cpi_total, reference_date")
+            .order("reference_date", desc=True)
+            .limit(1)
+            .execute()
+        ).data or []
+        gpr = (
+            sb.table("indicator_gpr_monthly_logs")
+            .select("gpr_original, reference_date")
+            .order("reference_date", desc=True)
+            .limit(1)
+            .execute()
+        ).data or []
+
+        result: dict = {}
+        if ecos:
+            result["krw_usd_rate"] = ecos[0].get("krw_usd_rate")
+        if fred:
+            result["fred_wti"] = fred[0].get("fred_wti")
+        if kosis:
+            result["cpi_total"] = kosis[0].get("cpi_total")
+        if gpr:
+            result["gpr"] = gpr[0].get("gpr_original")
+        return result
+    except Exception as e:
+        _log(f"indicator fetch error: {e}")
+        return {}
+
+
+def _save_briefing(sb, briefing_date: str, result: dict, source_count: int, indicators: dict) -> None:
+    row = {
+        "briefing_date": briefing_date,
+        "headline": result.get("headline", ""),
+        "overview": result.get("overview", ""),
+        "items": result.get("items", []),
+        "overall_risk": result.get("overall_risk", "medium"),
+        "consumer_tip": result.get("consumer_tip"),
+        "indicators": indicators,
+        "source_count": source_count,
+    }
+    sb.table("daily_briefings").upsert(row, on_conflict="briefing_date").execute()
+
+
+async def main(briefing_date: str | None = None) -> None:
+    load_environment()
+    today = briefing_date or date.today().isoformat()
+    _log(f"start date={today}")
+
+    sb = create_sb()
+
+    analyses = _fetch_today_analyses(sb, today)
+    causal_rows = _fetch_today_causal(sb, today)
+    indicators = _fetch_latest_indicators(sb)
+
+    _log(f"analyses={len(analyses)} causal={len(causal_rows)} indicators={list(indicators.keys())}")
+
+    result = await run_briefing_chain(
+        briefing_date=today,
+        analyses=analyses,
+        causal_rows=causal_rows,
+        indicators=indicators,
+    )
+
+    _log(f"headline={result.get('headline')}")
+    _log(f"overall_risk={result.get('overall_risk')} items={len(result.get('items', []))}")
+
+    _save_briefing(sb, today, result, source_count=len(analyses), indicators=indicators)
+    _log("saved to daily_briefings")
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    target_date = None
+    for arg in sys.argv[1:]:
+        if arg.startswith("--date="):
+            target_date = arg.split("=", 1)[1].strip()
+        elif not arg.startswith("--"):
+            target_date = arg.strip()
+    asyncio.run(main(target_date))

--- a/prd/llm/chains/briefing_runner.py
+++ b/prd/llm/chains/briefing_runner.py
@@ -1,0 +1,92 @@
+"""LLM3 briefing chain — generates a daily consumer price briefing."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from prd.config import get_gemini_api_key, get_gemini_model
+from prd.llm.chains.llm_runner import _create_model, _message_text, _preview_text
+from prd.llm.prompts.briefing_prompt import BRIEFING_PROMPT
+
+
+def _fmt_indicator(indicators: dict) -> str:
+    lines: list[str] = []
+    if v := indicators.get("krw_usd_rate"):
+        lines.append(f"원/달러 환율: {v:,.0f}원")
+    if v := indicators.get("fred_wti") or indicators.get("wti"):
+        lines.append(f"국제 유가(WTI): ${v:.1f}/배럴")
+    if v := indicators.get("cpi_total"):
+        lines.append(f"한국 소비자물가(CPI): {v:.1f}%")
+    if v := indicators.get("gpr_7d") or indicators.get("gpr"):
+        lines.append(f"지정학적 리스크(GPR): {v:.0f}")
+    return "\n".join(lines) if lines else "최신 지표 없음"
+
+
+def _fmt_categories(causal_rows: list[dict]) -> str:
+    agg: dict[str, dict[str, int]] = {}
+    for row in causal_rows:
+        cat = row.get("category") or "기타"
+        cat_ko = row.get("category_ko") or cat
+        direction = row.get("direction") or "neutral"
+        if cat not in agg:
+            agg[cat] = {"category_ko": cat_ko, "up": 0, "down": 0, "neutral": 0}
+        agg[cat][direction] = agg[cat].get(direction, 0) + 1
+
+    lines: list[str] = []
+    for entry in sorted(agg.values(), key=lambda x: x["up"] + x["down"], reverse=True)[:8]:
+        name = entry["category_ko"]
+        lines.append(f"- {name}: 상승 {entry['up']}건 / 하락 {entry['down']}건 / 중립 {entry['neutral']}건")
+    return "\n".join(lines) if lines else "집계 데이터 없음"
+
+
+def _fmt_news(analyses: list[dict]) -> str:
+    lines: list[str] = []
+    for i, row in enumerate(analyses[:10], 1):
+        summary = (row.get("summary") or "").strip()
+        reliability = row.get("reliability") or 0
+        if summary:
+            lines.append(f"{i}. [{reliability:.0%}] {summary}")
+    return "\n".join(lines) if lines else "분석 데이터 없음"
+
+
+async def run_briefing_chain(
+    *,
+    briefing_date: str,
+    analyses: list[dict],
+    causal_rows: list[dict],
+    indicators: dict,
+) -> dict[str, Any]:
+    indicator_summary = _fmt_indicator(indicators)
+    category_summary = _fmt_categories(causal_rows)
+    news_summary = _fmt_news(analyses)
+    news_count = min(len(analyses), 10)
+
+    payload = {
+        "briefing_date": briefing_date,
+        "indicator_summary": indicator_summary,
+        "category_summary": category_summary,
+        "news_summary": news_summary,
+        "news_count": news_count,
+    }
+
+    model = _create_model(temperature=0.3, max_tokens=2048)
+    chain = BRIEFING_PROMPT | model
+    print(f"[LLM3] request date={briefing_date} news_count={news_count}")
+    response = await chain.ainvoke(payload)
+    text = _message_text(response)
+    print(f"[LLM3] response_preview={_preview_text(text)}")
+
+    raw = text.strip()
+    if raw.startswith("```"):
+        raw = "\n".join(raw.splitlines()[1:])
+        if raw.endswith("```"):
+            raw = raw[: raw.rfind("```")]
+
+    result = json.loads(raw)
+    result.setdefault("headline", "오늘의 물가 브리핑")
+    result.setdefault("overview", "")
+    result.setdefault("items", [])
+    result.setdefault("overall_risk", "medium")
+    result.setdefault("consumer_tip", None)
+    return result

--- a/prd/llm/prompts/briefing_prompt.py
+++ b/prd/llm/prompts/briefing_prompt.py
@@ -1,0 +1,70 @@
+from textwrap import dedent
+
+from langchain_core.prompts import ChatPromptTemplate
+
+BRIEFING_SYSTEM_PROMPT = dedent(
+    """
+    당신은 경제 전문가가 아닌 일반 소비자(주부, 직장인 등)를 위해
+    오늘의 물가 상황을 쉽게 설명하는 브리핑 작성 AI입니다.
+
+    입력:
+    - 오늘 날짜
+    - 최근 고신뢰 뉴스 분석 요약 목록
+    - 품목별 방향 집계 (up/down/neutral 개수)
+    - 최신 경제 지표 (환율, 유가, CPI 등)
+
+    출력 규칙:
+    1. 반드시 유효한 JSON 객체 하나만 출력합니다. 마크다운 펜스, 설명 텍스트 금지.
+    2. 전문 용어 금지. "유동성", "지정학적" 같은 말 대신 일상 언어를 사용합니다.
+    3. headline은 오늘 물가를 한 줄로 요약합니다 (40자 이내, 구체적으로).
+    4. overview는 "왜 그런지"를 쉽게 설명합니다 (80자 이내).
+    5. items는 실제로 영향이 있는 품목만 포함합니다 (최대 5개).
+       - direction이 neutral이면 items에서 제외합니다.
+       - summary는 "~할 수 있어요" 또는 "~예상이에요" 식의 부드러운 표현을 사용합니다 (30자 이내).
+       - reason은 이유를 한 문장으로 (50자 이내).
+    6. overall_risk: 오늘 전반적인 물가 부담 수준 ("low" | "medium" | "high").
+    7. consumer_tip: 소비자가 취할 수 있는 실용적 행동 팁 (선택, 없으면 null, 50자 이내).
+    8. 분석 데이터가 부족하거나 영향이 미미하면 headline에 "오늘은 물가 변동이 크지 않아요" 같이 솔직하게 작성합니다.
+
+    출력 JSON 형식:
+    {
+      "headline": "이번 주 휘발유·식품 가격 소폭 오를 전망",
+      "overview": "러시아 공급 감소로 국제 유가가 오르고, 원화 약세도 겹쳐 체감 물가가 높아질 수 있어요.",
+      "items": [
+        {
+          "category_ko": "연료",
+          "direction": "up",
+          "summary": "휘발유 가격이 오를 수 있어요",
+          "reason": "국제 유가 상승이 2~4주 후 주유소 가격에 반영됩니다."
+        }
+      ],
+      "overall_risk": "medium",
+      "consumer_tip": "이번 주는 주유를 미리 해두는 것이 유리할 수 있어요."
+    }
+    """
+).strip()
+
+BRIEFING_USER_PROMPT = dedent(
+    """
+    JSON 객체만 출력하세요.
+
+    [날짜]
+    {briefing_date}
+
+    [최신 경제 지표]
+    {indicator_summary}
+
+    [오늘 품목별 영향 집계]
+    {category_summary}
+
+    [고신뢰 뉴스 분석 요약 (상위 {news_count}건)]
+    {news_summary}
+    """
+).strip()
+
+BRIEFING_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        ("system", BRIEFING_SYSTEM_PROMPT),
+        ("human", BRIEFING_USER_PROMPT),
+    ]
+)


### PR DESCRIPTION
## Summary
- LLM3 Gemini 체인으로 매일 소비자용 물가 브리핑 자동 생성
- `/api/v1/briefing/today` 공개 API (인증 불필요)
- `/briefing` 공개 프론트 페이지 (일반 소비자용, RequireAuth 없음)

## 변경 파일
| 파일 | 내용 |
|------|------|
| `prd/llm/prompts/briefing_prompt.py` | LLM3 시스템/유저 프롬프트 |
| `prd/llm/chains/briefing_runner.py` | Gemini 호출 + 결과 파싱 |
| `prd/briefing_main.py` | 일별 cron 실행 엔트리포인트 |
| `backend/api/routes/briefing.py` | GET /today, GET /history |
| `backend/migrations/001_daily_briefings.sql` | daily_briefings 테이블 DDL |
| `front_web/src/pages/BriefingPage.tsx` | 소비자용 공개 페이지 |
| `front_web/src/app/router.tsx` | /briefing 라우트 추가 |
| `front_web/src/components/layout/Sidebar.tsx` | 브리핑 링크 추가 |
| `front_web/src/lib/api.ts` | briefingApi 추가 |

## 데이터 흐름
```
python -m prd.briefing_main   # 매일 cron
  → news_analyses (고신뢰 top 10)
  → causal_chains 품목별 집계
  → 최신 indicator (환율/유가/CPI)
  → LLM3 (Gemini) → 브리핑 JSON
  → daily_briefings 테이블 upsert
  → GET /api/v1/briefing/today
  → BriefingPage (/briefing)
```

## DB 설정 필요
`backend/migrations/001_daily_briefings.sql` 을 Supabase SQL 에디터에서 실행해야 합니다.

## Test plan
- [ ] `backend/migrations/001_daily_briefings.sql` Supabase 실행
- [ ] `python -m prd.briefing_main` 로컬 실행 확인
- [ ] `GET /api/v1/briefing/today` 응답 확인
- [ ] `/briefing` 페이지 렌더링 확인 (로그인 없이)
- [ ] 사이드바 "오늘의 물가 브리핑" 링크 확인

close #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)