### PR TITLE
fix(data_collector): GPR 일일 수집 테이블을 indicator_gpr_daily_logs로 통일 (#85)

### DIFF
--- a/data_collector/src/data_mining/GPR/fetch-gpr-daily.js
+++ b/data_collector/src/data_mining/GPR/fetch-gpr-daily.js
@@ -34,25 +34,22 @@ async function fetchDailyGPR() {
     const latest = rows[rows.length - 1];
 
     const record = {
-      category: "Economy",
-      ai_gpr_index: parseFloat(latest["GPR_AI"]), // 👈 ai_gpr_index로 변경
+      ai_gpr_index: parseFloat(latest["GPR_AI"]),
       oil_disruptions: parseFloat(latest["GPR_OIL"] || 0),
       gpr_original: parseFloat(latest["GPR_AER"] || 0),
       non_oil_gpr: parseFloat(latest["GPR_NONOIL"] || 0),
-      unit: "index",
       reference_date: latest["Date"],
-      collected_at: new Date().toISOString(),
     };
 
-    // ✅ indicator_daily_logs 테이블로 upsert
-    const { data, error } = await supabase
-      .from("indicator_daily_logs")
+    // 대시보드·API·웹은 indicator_gpr_daily_logs 만 조회함 (indicator_daily_logs 아님)
+    const { error } = await supabase
+      .from("indicator_gpr_daily_logs")
       .upsert(record, { onConflict: "reference_date" });
 
     if (error) throw error;
     console.log(`🚀 [Daily] 업데이트 성공: ${record.reference_date}`);
     console.log(
-      `📊 지수: ${record.AI_GPR_Index} / 석유리스크: ${record.oil_disruptions}`,
+      `📊 지수: ${record.ai_gpr_index} / 석유리스크: ${record.oil_disruptions}`,
     );
   } catch (error) {
     console.error("❌ 일일 데이터 수집 실패:", error.message);

--- a/data_collector/src/data_mining/GPR/seed-gpr-daily.js
+++ b/data_collector/src/data_mining/GPR/seed-gpr-daily.js
@@ -28,21 +28,16 @@ async function seedDailyGPR() {
         console.log(`🔍 필터링된 데이터 개수: ${filteredRows.length}개`);
 
         const records = filteredRows.map(row => ({
-            category: "Economy",
             ai_gpr_index: parseFloat(row["GPR_AI"]),
             oil_disruptions: parseFloat(row["GPR_OIL"] || 0),
             gpr_original: parseFloat(row["GPR_AER"] || 0),
             non_oil_gpr: parseFloat(row["GPR_NONOIL"] || 0),
-            unit: "index",
             reference_date: row["Date"],
-            collected_at: new Date().toISOString(),
         }));
 
-        // ✅ 대량 삽입 (Upsert)
-        // 한 번에 너무 많은 데이터를 넣으면 에러가 날 수 있으니 500개씩 끊어서 넣거나, 
-        // 여기서는 3년치(약 1,100개)이므로 한 번에 시도해봅니다.
+        // 대시보드·API와 동일 테이블 (fetch-gpr-daily.js 와 맞춤)
         const { error } = await supabase
-            .from("indicator_daily_logs")
+            .from("indicator_gpr_daily_logs")
             .upsert(records, { onConflict: "reference_date" });
 
         if (error) throw error;


### PR DESCRIPTION
## 요약
- \etch-gpr-daily.js\, \seed-gpr-daily.js\의 upsert 대상을 \indicator_gpr_daily_logs\로 변경 (DB·백엔드·프론트와 일치).

Closes #85

Made with [Cursor](https://cursor.com)