### PR TITLE
모바일 디자인 통일 적용

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ These are **hard expectations** for humans and agents—not optional style tips.
 - **Error handling**: Handle errors explicitly (`try/catch` in JS/TS, `try/except` in Python).
 - **Comments**: Only for non-obvious logic—do not narrate obvious code.
 - **After edits**: Run the relevant local commands under **Verification and agent harnesses → Automated test entrypoints**.
+- **No guessing — verify**: 테이블·컬럼·브랜치 상태·에러 원인·외부 데이터 갱신 여부 등은 **추정으로 단정하지 말고** 저장소 검색, DB/스키마 조회, 명령 실행, API·워크플로 로그 확인 등으로 **직접 검증**한다. 환경상 검증이 불가하면 그 한계를 밝히고, 확인에 필요한 구체적 단계(쿼리, 파일 경로, 명령)를 제시한다.
 
 ## Error handling rules
 

--- a/docs/design-unification-spec.md
+++ b/docs/design-unification-spec.md
@@ -1,245 +1,461 @@
 # Costview 디자인 통일 사양서
 
-> 기준: `front_web` (Vite + React + Tailwind, 서민 친화적 디자인 완성본)  
+> 기준: `front_web` (Vite + React + Tailwind)  
 > 대상: `front_app` (Expo React Native)  
-> 근거: `.claude/skills/skills/frontend-design/SKILL.md`
+> 철학 근거: `.claude/skills/skills/frontend-design/SKILL.md`  
+> **소스 확인**: 변경 대상 전체 파일 직접 읽음 + 하드코딩 색상 전수 grep 완료
 
 ---
 
-## 1. 현황 분석 — 두 앱의 차이
+## 0. 디자인 철학 (SKILL.md 적용)
+
+### 0-1. Aesthetic Direction — 서민 친화 따뜻한 정보 앱
+
+| 항목 | 방향 |
+|------|------|
+| **Purpose** | 주부·직장인이 물가·경제 지표를 부담 없이 확인하는 앱. 전문가용 금융 앱처럼 차갑지 않게. |
+| **Tone** | Warm & Trustworthy — 오렌지 계열의 따뜻함 + 크림 배경의 부드러움. 신뢰감과 친근함 공존. |
+| **Differentiation** | "숫자를 읽어주는 친구" 같은 인터페이스. 상승=빨강/하락=초록의 직관적 색상 언어. 흰 헤더 + 오렌지 강조의 단순하고 일관된 시각 언어. |
+| **Anti-pattern** | 민트/청록 계열 핀테크 클리셰, 과도한 그라디언트, generic 다크 테마 금지. |
+
+### 0-2. Typography
+
+- **본문·레이블·버튼**: `Plus Jakarta Sans` (400 / 500 / 700) — Inter·Roboto 대신 개성 있는 humanist sans
+- **숫자(환율·지수·가격)**: `DM Mono` (400) — 모노스페이스로 수치 정렬과 신뢰감 확보
+- **적용 우선순위**: 헤더 타이틀 → KPI 수치 → 카드 레이블 → 본문 순으로 적용
+- **금지**: 기본 RN 시스템 폰트(`System`, 미지정 fontFamily)를 주요 UI 요소에 그대로 사용하지 않는다.
+
+### 0-3. Color Philosophy
+
+- **지배색 + 날카로운 강조색**: 크림 배경(`#FFFBF7`) 위에 오렌지(`#F97316`) 단색 강조. 색이 많아지면 신뢰감이 떨어진다.
+- **방향 색상은 소비자 직관 우선**: 상승(가격 오름)=나쁨=빨강(`#EF4444`), 하락=좋음=초록(`#22C55E`). 금융권 관례(상승=초록)와 반대이며, 이 차이는 의도적이다.
+- **토큰 시스템 강제**: 하드코딩 색상은 유지보수를 망친다. 모든 UI 색상은 `COLORS.*` 토큰을 통해서만 참조한다.
+
+### 0-4. Motion (React Native)
+
+- **원칙**: 애니메이션은 "있음을 알리기" 위해서가 아니라 "상태 전환을 명확히" 하기 위해 사용한다.
+- **적용 대상**: 탭 전환 시 활성 인디케이터 슬라이드, 카드 로드 시 fade-in (`Animated.timing`), 풀-투-리프레시 오렌지 스피너.
+- **금지**: 불필요한 bounce, 과도한 scale 애니메이션, 인터랙션 없는 장식 애니메이션.
+- **구현 도구**: `Animated` API (RN 내장) 우선. 복잡한 시퀀스는 `react-native-reanimated`.
+
+### 0-5. 이 사양서에서 의도적으로 제외한 항목
+
+| SKILL.md 항목 | 제외 이유 |
+|---------------|-----------|
+| Spatial Composition (비대칭·레이아웃 파괴) | front_app 레이아웃은 모바일 UX 최적화 완료 상태, 구조 변경은 다음 이슈 |
+| Backgrounds & Visual Details (그라디언트·노이즈 텍스처) | RN의 플랫폼 제약 + 서민 친화 앱 톤에 불필요 |
+| 다크 테마 | 추후 이슈로 분리 |
+
+---
+
+## 1. 핵심 전제 (구현)
+
+### 0-1. `COLORS.headerBg` 이중 용도 문제
+
+현재 `colors.js`에 `primary` 토큰이 없다. `headerBg: '#0D9488'`(민트)가 두 역할을 겸한다.
+
+| 역할 | 현재 | 변경 후 | 처리 방식 |
+|------|------|---------|----------|
+| 배경색 (header, modal 등) | `COLORS.headerBg` → 민트 | `COLORS.headerBg` → 흰색 | colors.js 토큰 교체로 자동 |
+| 전경색 (활성 텍스트·스피너·tintColor) | `COLORS.headerBg` → 민트 | `COLORS.primary` → 오렌지 | **직접 교체 필요** |
+
+### 0-2. 자동 반영 vs 직접 수정 구분
+
+colors.js 교체만으로 처리되는 것:
+- 헤더 `backgroundColor` (모든 스크린)
+- `COLORS.screenBg`, `COLORS.tabActive`, `COLORS.tagUpBg` 등 토큰 참조
+
+직접 수정해야 하는 것:
+- 흰색 배경으로 바뀐 헤더 위의 **`rgba(255,255,255,...)` 인라인 색상** (보이지 않게 됨)
+- **하드코딩된 `#1E3A5F` (남색)** — LoadingView, FilterChips
+- **`changeColor`, `gaugeBarColor` 등 계산식 색상**
+
+---
+
+## 1. 현황 분석
 
 | 항목 | front_web (기준) | front_app (현재) | 불일치 |
 |------|-----------------|-----------------|--------|
-| 주색상 | 오렌지 `#F97316` | 민트 `#0D9488` | ❌ |
-| 헤더 배경 | 흰색 + 하단 테두리 | 민트 배경색 | ❌ |
-| 상승(Up) 색상 | 빨강 `#EF4444` | 주황 `#D85A30` | ❌ |
-| 하락(Down) 색상 | 초록 `#22C55E` | 민트초록 `#1D9E75` | ❌ |
+| 주색상 토큰 | `primary: #F97316` | **없음** (`headerBg` 대용) | ❌ |
+| 헤더 배경 | 흰색 + 테두리 | 민트 `#0D9488` | ❌ |
+| StatusBar | dark-content | light-content | ❌ |
+| 상승 색상 | `#EF4444` | `#D85A30` | ❌ |
+| 하락 색상 | `#22C55E` | `#1D9E75` | ❌ |
 | 화면 배경 | 크림 `#FFFBF7` | 청회색 `#F4F7FA` | ❌ |
-| 탭 활성 색상 | 오렌지 `#F97316` | 민트 `#0D9488` | ❌ |
-| 태그 상승 배경 | `#FEE2E2` | `#FCEBEB` | ❌ |
-| 태그 상승 텍스트 | `#B91C1C` | `#791F1F` | ❌ |
-| 태그 하락 배경 | `#DCFCE7` | `#EAF3DE` | ❌ |
-| 태그 하락 텍스트 | `#15803D` | `#27500A` | ❌ |
-| 강도 점(high) | `#EF4444` | `#D85A30` | ❌ |
-| 강도 점(med) | `#F59E0B` | `#EF9F27` | ❌ |
-| 폰트 | Plus Jakarta Sans + DM Mono | 기본 RN 폰트 | ❌ |
-| 카드 모서리 | 12px (`rounded-xl`) | 14px | △ |
+| 활성 칩/탭 배경 | 오렌지 | 남색 `#1E3A5F` (FilterChips) | ❌ |
+| 태그 up bg/text | `#FEE2E2` / `#B91C1C` | `#FCEBEB` / `#791F1F` | ❌ |
+| 태그 down bg/text | `#DCFCE7` / `#15803D` | `#EAF3DE` / `#27500A` | ❌ |
+| 강도 점 high | `#EF4444` | `#D85A30` | ❌ |
+| 강도 점 med | `#F59E0B` | `#EF9F27` | ❌ |
+| ai_gpr_index 레이블 | **글로벌 불안지수** | **글로벌 위기 지수** | ❌ 용어 불일치 → 섹션 8 참고 |
+| 폰트 | Plus Jakarta Sans + DM Mono | 기본 RN | ❌ |
+| 카드 모서리 | 12px | 14px | △ |
 
 ---
 
-## 2. 통일 디자인 토큰
-
-### 2-1. 색상 (`front_app/src/constants/colors.js`)
+## 2. 통일 디자인 토큰 (`front_app/src/constants/colors.js` 전체 교체)
 
 ```js
 export const COLORS = {
-  // ── Primary (오렌지 계열) ───────────────────────────
-  primary:        '#F97316',   // 주색상 (탭 활성, 강조)
-  primaryDark:    '#EA580C',   // 진한 주색상 (활성 NavLink 등)
-  primaryAccent:  '#FED7AA',   // 연한 주색상 (배지, 게이지 바)
-  surface:        '#FFF7ED',   // 카드 배경 강조 영역 (orange-50)
+  // ── Primary (오렌지) — 신규 추가 ──────────────────────────
+  primary:        '#F97316',
+  primaryDark:    '#EA580C',
+  primaryAccent:  '#FED7AA',
+  surface:        '#FFF7ED',   // orange-50
 
-  // ── 방향 (소비자 직관: 상승=나쁨=빨강, 하락=좋음=초록) ──
-  up:             '#EF4444',   // 상승 — 빨강
-  down:           '#22C55E',   // 하락 — 초록
-  neutral:        '#9CA3AF',   // 중립 — 회색
-  upLight:        '#FEE2E2',   // 상승 배경
-  downLight:      '#DCFCE7',   // 하락 배경
+  // ── 방향 ─────────────────────────────────────────────────
+  up:             '#EF4444',
+  down:           '#22C55E',
+  neutral:        '#9CA3AF',
+  upLight:        '#FEE2E2',
+  downLight:      '#DCFCE7',
 
-  // ── 태그 ──────────────────────────────────────────
+  // ── 태그 ─────────────────────────────────────────────────
   tagUpBg:        '#FEE2E2',
   tagUpText:      '#B91C1C',
   tagDownBg:      '#DCFCE7',
   tagDownText:    '#15803D',
 
-  // ── 강도 점 ───────────────────────────────────────
+  // ── 강도 점 ──────────────────────────────────────────────
   dotHigh:        '#EF4444',
   dotMed:         '#F59E0B',
   dotLow:         '#E5E7EB',
 
-  // ── 차트 시리즈 ───────────────────────────────────
-  warning:        '#F59E0B',
-  series3:        '#6366F1',
-  series4:        '#EC4899',
+  // ── 신뢰도 ───────────────────────────────────────────────
+  highBg:         '#FFF7ED',
+  highText:       '#EA580C',
+  medBg:          '#FFFBEB',
+  medText:        '#92400E',
+  lowBg:          '#F9FAFB',
+  lowText:        '#6B7280',
 
-  // ── 배경 / 레이아웃 ───────────────────────────────
-  screenBg:       '#FFFBF7',   // 전체 배경 (크림)
+  // ── 배경 / 레이아웃 ───────────────────────────────────────
+  screenBg:       '#FFFBF7',
   white:          '#FFFFFF',
   border:         '#F3F4F6',
+  borderHalf:     '#F3F4F6',
 
-  // ── 헤더 (흰색 + 테두리) ──────────────────────────
+  // ── 헤더 (흰색 + 테두리) ─────────────────────────────────
   headerBg:       '#FFFFFF',
   headerBorder:   '#F3F4F6',
-  headerText:     '#111827',
+  headerText:     '#111827',   // 흰 배경이므로 검정으로 변경
   headerMuted:    '#6B7280',
+  headerAccent:   '#F97316',
 
-  // ── 탭 ────────────────────────────────────────────
+  // ── 탭 ───────────────────────────────────────────────────
   tabActive:      '#F97316',
   tabInactive:    '#9CA3AF',
 
-  // ── 텍스트 ────────────────────────────────────────
+  // ── 텍스트 ───────────────────────────────────────────────
   textPrimary:    '#111827',
   textMuted:      '#6B7280',
   textLight:      '#9CA3AF',
-
-  // ── 신뢰도 (ReliabilityBadge) ─────────────────────
-  highBg:         '#FFF7ED',   // orange-50
-  highText:       '#EA580C',   // orange-600
-  medBg:          '#FFFBEB',   // amber-50
-  medText:        '#92400E',   // amber-800
-  lowBg:          '#F9FAFB',
-  lowText:        '#6B7280',
 };
-```
-
-### 2-2. 방향 상수 (`front_app/src/constants/category.js`)
-
-```js
-export const DIRECTION_MAP = {
-  up:      { label: '▲ 상승', color: '#EF4444', dotColor: '#EF4444' },
-  down:    { label: '▼ 하락', color: '#22C55E', dotColor: '#22C55E' },
-  neutral: { label: '─ 중립', color: '#9CA3AF', dotColor: '#9CA3AF' },
-};
-
-export const MAGNITUDE_MAP = {
-  high:   { label: '강함', dots: ['#EF4444', '#EF4444', '#EF4444'] },
-  medium: { label: '보통', dots: ['#F59E0B', '#F59E0B', '#E5E7EB'] },
-  low:    { label: '약함', dots: ['#E5E7EB', '#E5E7EB', '#E5E7EB'] },
-};
-
-export function getReliabilityBadge(r) {
-  if (r >= 0.8) return { label: `${Math.round(r * 100)}%`, bg: '#FFF7ED', color: '#EA580C' };
-  if (r >= 0.5) return { label: `${Math.round(r * 100)}%`, bg: '#FFFBEB', color: '#92400E' };
-  if (r >= 0.3) return { label: `${Math.round(r * 100)}%`, bg: '#F9FAFB', color: '#6B7280' };
-  return null;
-}
-```
-
-### 2-3. 타이포그래피
-
-React Native에서 웹 폰트(`Plus Jakarta Sans`, `DM Mono`) 사용:
-
-```bash
-# 설치
-npx expo install @expo-google-fonts/plus-jakarta-sans @expo-google-fonts/dm-mono expo-font
-```
-
-```js
-// App.jsx — 폰트 로드
-import { useFonts } from 'expo-font';
-import {
-  PlusJakartaSans_400Regular,
-  PlusJakartaSans_500Medium,
-  PlusJakartaSans_700Bold,
-} from '@expo-google-fonts/plus-jakarta-sans';
-import { DMMono_400Regular } from '@expo-google-fonts/dm-mono';
-
-// fontFamily 적용 규칙
-// - 본문, 레이블, 버튼: 'PlusJakartaSans_700Bold' / '_500Medium' / '_400Regular'
-// - 숫자(환율, 지수 등): 'DMMono_400Regular'
 ```
 
 ---
 
-## 3. 컴포넌트별 변경 사항
+## 3. 파일별 변경 사항 (하드코딩 포함 전수 기재)
 
-### 3-1. `front_app/src/constants/colors.js`
-- **전체 교체** → 위 2-1 토큰으로 대체
+### 3-1. `src/constants/category.js`
 
-### 3-2. `front_app/src/constants/category.js`
-- `DIRECTION_MAP` color/dotColor 값 교체 → 2-2 참고
-- `MAGNITUDE_MAP` dots 배열 교체 → 2-2 참고
-- `getReliabilityBadge` bg/color 값 교체 → 2-2 참고
+색상값만 교체. "글로벌 불안지수" 문구는 이 파일에 없으므로 여기서 수정하지 않는다.
 
-### 3-3. `front_app/src/screens/DashboardScreen.jsx`
+```js
+// DIRECTION_MAP
+up:      { color: '#EF4444', dotColor: '#EF4444' }
+down:    { color: '#22C55E', dotColor: '#22C55E' }
+neutral: { color: '#9CA3AF', dotColor: '#9CA3AF' }
+
+// MAGNITUDE_MAP
+high:   { dots: ['#EF4444', '#EF4444', '#EF4444'] }
+medium: { dots: ['#F59E0B', '#F59E0B', '#E5E7EB'] }
+
+// getReliabilityBadge
+r >= 0.8 → bg: '#FFF7ED', color: '#EA580C'
+r >= 0.5 → bg: '#FFFBEB', color: '#92400E'
+r >= 0.3 → bg: '#F9FAFB', color: '#6B7280'
+```
+
+---
+
+### 3-2. `src/screens/DashboardScreen.jsx`
 
 | 위치 | 현재 | 변경 후 |
 |------|------|---------|
-| `styles.header backgroundColor` | `COLORS.headerBg` (민트) | `COLORS.headerBg` (흰색, 토큰 교체로 자동 반영) |
 | `StatusBar barStyle` | `light-content` | `dark-content` |
-| `StatusBar backgroundColor` | `COLORS.headerBg` | `COLORS.headerBg` |
-| `styles.headerTitle color` | `COLORS.headerText` | 토큰 교체로 자동 반영 |
-| `styles.riskCard backgroundColor` | `rgba(255,255,255,0.10)` | `#FFFFFF` + border |
-| `styles.riskLabel color` | `rgba(255,255,255,0.9)` | `COLORS.textMuted` |
-| `styles.riskValue color` | `COLORS.headerText` | `COLORS.textPrimary` |
-| `styles.screenBg` | `#F4F7FA` | `COLORS.screenBg` (크림) |
-| 게이지 바 색상 로직 | 파랑/노랑/주황/빨강 4단계 | `COLORS.primaryAccent` 단색 |
-| `changeColor` 계산 | `#FF8A7A` / `#6EE7B7` | `COLORS.up` / `COLORS.down` |
+| `StatusBar backgroundColor` | `COLORS.headerBg` | `COLORS.headerBg` (토큰→흰색) |
+| `changeColor` 계산 (line ~33) | `'#FF8A7A'` / `'#6EE7B7'` | `COLORS.up` / `COLORS.down` |
+| `gaugeBarColor` 4단계 계산 (line ~47–50) | 파랑/노랑/주황/빨강 | `COLORS.primaryAccent` 단색 |
+| 인라인 desc `rgba(255,255,255,0.4)` (line ~62) | 반투명 흰색 | `COLORS.textLight` |
+| `riskCard.backgroundColor` | `rgba(255,255,255,0.10)` | `COLORS.white` |
+| `riskLabel.color` | `rgba(255,255,255,0.9)` | `COLORS.textMuted` |
+| `riskBar.backgroundColor` | `rgba(255,255,255,0.15)` | `COLORS.border` |
+| `riskBarFill.backgroundColor` | `rgba(255,255,255,0.4)` | `COLORS.primaryAccent` |
+| `riskDate.color` | `rgba(255,255,255,0.55)` | `COLORS.textLight` |
+| `ActivityIndicator color` | `COLORS.headerBg` | `COLORS.primary` |
+| `RefreshControl tintColor/colors` | `COLORS.headerBg` | `COLORS.primary` |
+| `RISK_ITEMS[0].label` (line 237) | `'글로벌 위기 지수'` | `'글로벌 불안지수'` |
+| `RISK_ITEMS[0].desc` (line 237) | `'지정학적 위기 지수'` | `'글로벌 불안지수'` |
+| bottomsheet 본문 (line ~371) | `'본 글로벌 위기 지수는'` | `'본 글로벌 불안지수는'` |
 
-### 3-4. `front_app/src/screens/NewsListScreen.jsx`
-- 검색바/필터 활성 색상: `COLORS.headerBg` → `COLORS.primary`
-- 상단 헤더 배경: 민트 → 흰색
+---
 
-### 3-5. `front_app/src/screens/RiskScreen.jsx`
-- 헤더 배경: 민트 → 흰색
-- 탭 활성 색상: `COLORS.tabActive` (토큰 교체로 자동 반영)
+### 3-3. `src/screens/NewsListScreen.jsx`
 
-### 3-6. `front_app/src/screens/SettingsScreen.jsx`
-- 헤더 배경: 민트 → 흰색
+| 위치 | 현재 | 변경 후 |
+|------|------|---------|
+| `StatusBar barStyle` | `light-content` | `dark-content` |
+| `searchBar.backgroundColor` | `rgba(255,255,255,0.12)` | `#F9FAFB` |
+| `chip.borderColor` | `rgba(255,255,255,0.2)` | `COLORS.border` |
+| `chipText.color` | `rgba(255,255,255,0.65)` | `COLORS.textMuted` |
+| `chipTextActive.color` | `COLORS.headerBg` | `COLORS.primary` |
+| `ActivityIndicator color` (3곳) | `COLORS.headerBg` | `COLORS.primary` |
+| `RefreshControl tintColor/colors` | `COLORS.headerBg` | `COLORS.primary` |
 
-### 3-7. `front_app/src/components/LoadingView.jsx`
-- 스피너 색상: `COLORS.headerBg` → `COLORS.primary`
+---
+
+### 3-4. `src/screens/RiskScreen.jsx`
+
+| 위치 | 현재 | 변경 후 |
+|------|------|---------|
+| `StatusBar barStyle` | `light-content` | `dark-content` |
+| `tabBtn.borderColor` | `rgba(255,255,255,0.2)` | `COLORS.border` |
+| `tabBtnText.color` | `rgba(255,255,255,0.65)` | `COLORS.textMuted` |
+| `tabBtnTextActive.color` | `COLORS.headerBg` | `COLORS.primary` |
+| `controlDivider.backgroundColor` | `rgba(255,255,255,0.25)` | `COLORS.border` |
+| `rangeChip.borderColor` | `rgba(255,255,255,0.15)` | `COLORS.border` |
+| `rangeChipActive.borderColor` | `rgba(255,255,255,0.5)` | `COLORS.primary` |
+| `rangeChipActive.backgroundColor` | `rgba(255,255,255,0.1)` | `COLORS.surface` |
+| `rangeChipText.color` | `rgba(255,255,255,0.5)` | `COLORS.textMuted` |
+| `rangeChipTextActive.color` | `rgba(255,255,255,1)` | `COLORS.primary` |
+| `modalBtnApply.backgroundColor` | `COLORS.headerBg` | `COLORS.primary` |
+| `fsHeader.backgroundColor` | `COLORS.headerBg` | `COLORS.primary` |
+| `fsCloseBtn.backgroundColor` | `rgba(255,255,255,0.2)` | `rgba(0,0,0,0.1)` |
+| `ActivityIndicator color` | `COLORS.headerBg` | `COLORS.primary` |
+| `RefreshControl tintColor/colors` | `COLORS.headerBg` | `COLORS.primary` |
+| `ALL_SERIES` 차트 색상 | 하드코딩 다색 | **유지** (데이터 시리즈 구분용) |
+| `ALL_SERIES.gpr[0].label` (line 37) | `'글로벌 위기 지수'` | `'글로벌 불안지수'` |
+
+---
+
+### 3-5. `src/screens/SettingsScreen.jsx`
+
+| 위치 | 현재 | 변경 후 |
+|------|------|---------|
+| `StatusBar barStyle` | `light-content` | `dark-content` |
+| `loadingBox.backgroundColor` | `'#EFF6FF'` | `COLORS.surface` |
+| `loadingBox.borderColor` | `'#BFDBFE'` | `COLORS.primaryAccent` |
+| `loginButton.backgroundColor` | `COLORS.headerBg` | `COLORS.primary` |
+| `profileAvatar.backgroundColor` | `COLORS.headerBg` | `COLORS.primary` |
+| `Switch trackColor.true` (line 348) | `COLORS.headerBg` | `COLORS.primary` |
+| `ActivityIndicator color` | `COLORS.headerBg` | `COLORS.primary` |
+
+---
+
+### 3-6. `src/screens/PredictionListScreen.jsx`
+
+| 위치 | 현재 | 변경 후 |
+|------|------|---------|
+| `StatusBar barStyle` | `light-content` | `dark-content` |
+| `chip.borderColor` | `rgba(255,255,255,0.2)` | `COLORS.border` |
+| `chipText.color` | `rgba(255,255,255,0.65)` | `COLORS.textMuted` |
+| `chipTextActive.color` | `COLORS.headerBg` | `COLORS.primary` |
+| `ActivityIndicator color` | `COLORS.headerBg` | `COLORS.primary` |
+| `RefreshControl tintColor/colors` | `COLORS.headerBg` | `COLORS.primary` |
+
+---
+
+### 3-7. `src/components/LoadingView.jsx`
+
+| 위치 | 현재 | 변경 후 |
+|------|------|---------|
+| `ActivityIndicator color` | `COLORS.primary ?? '#1E3A5F'` | `COLORS.primary` (fallback 제거) |
+| `retryBtn.backgroundColor` | `'#1E3A5F'` | `COLORS.primary` |
+
+---
+
+### 3-8. `src/components/FilterChips.jsx`
+
+| 위치 | 현재 | 변경 후 |
+|------|------|---------|
+| `chipActive.backgroundColor` | `'#1E3A5F'` | `COLORS.primary` |
+| `chipActive.borderColor` | `'#1E3A5F'` | `COLORS.primary` |
+
+> **import 추가 필요**: `import { COLORS } from '../constants/colors';`
+
+---
+
+### 3-9. `src/components/PredictionCard.jsx`
+
+| 위치 | 현재 | 변경 후 |
+|------|------|---------|
+| `predPreviewTag.color` | `COLORS.headerBg` | `COLORS.primary` |
+
+---
+
+### 3-10. `src/components/NewsDetailView.jsx`
+
+| 위치 | 현재 | 변경 후 |
+|------|------|---------|
+| `StatusBar barStyle` | `light-content` | `dark-content` |
+| `header.backgroundColor` | `COLORS.headerBg` | 토큰 교체로 자동 흰색 |
+| 헤더 내 텍스트 `rgba(255,255,255,0.8)` (line 157) | 반투명 흰색 | `COLORS.textPrimary` |
+
+---
+
+### 3-11. `src/components/PredictionDetailView.jsx`
+
+| 위치 | 현재 | 변경 후 |
+|------|------|---------|
+| `header.backgroundColor` | `COLORS.headerBg` | 토큰 교체로 자동 흰색 |
+| `backText.color` (line 199) | `rgba(255,255,255,0.7)` | `COLORS.textPrimary` |
+| `newsCard.borderLeftColor` | `COLORS.headerBg` | `COLORS.primary` |
+| `newsSource.color` | `COLORS.headerBg` | `COLORS.primary` |
+| `linkText.color` | `COLORS.headerBg` | `COLORS.primary` |
+
+---
+
+### 3-12. `src/App.jsx`
+
+| 위치 | 현재 | 변경 후 |
+|------|------|---------|
+| `ActivityIndicator color` | `COLORS.headerBg` | `COLORS.primary` |
 
 ---
 
 ## 4. 구현 순서
 
 ```
-1단계 — 토큰 교체 (자동 전파)
-  └── colors.js 전체 교체
-  └── category.js DIRECTION_MAP, MAGNITUDE_MAP, getReliabilityBadge 교체
-      → 대부분의 컴포넌트는 토큰만 바꾸면 자동 반영
+1단계 — 토큰 교체
+  └── colors.js 전체 교체 (primary 토큰 추가, headerBg→흰색, headerText→검정)
+  └── category.js 색상값·용어 교체
 
-2단계 — 하드코딩 값 수정
-  └── DashboardScreen.jsx 헤더/RiskCard 인라인 색상 교체
-  └── 각 Screen의 StatusBar barStyle 수정
+2단계 — 인라인 하드코딩 교체 (헤더 흰색 전환 후 보이지 않는 색상 우선)
+  └── DashboardScreen: rgba 인라인 → 토큰, changeColor·gaugeBarColor 교체
+  └── NewsListScreen: rgba 인라인 → 토큰
+  └── RiskScreen: rgba 인라인 → 토큰, tabBtn·rangeChip·fsCloseBtn
+  └── PredictionListScreen: rgba 인라인 → 토큰
+  └── NewsDetailView: 헤더 내 rgba 텍스트
+  └── PredictionDetailView: backText rgba
 
-3단계 — 폰트 적용 (선택)
-  └── expo-google-fonts 패키지 설치
-  └── App.jsx 폰트 로드
+3단계 — 전경색 COLORS.headerBg → COLORS.primary
+  └── DashboardScreen, NewsListScreen, RiskScreen, SettingsScreen, PredictionListScreen,
+      App.jsx: ActivityIndicator·RefreshControl
+  └── SettingsScreen: loginButton, profileAvatar, Switch
+  └── LoadingView: primary 토큰 fallback 제거, retryBtn
+  └── FilterChips: chipActive (import 추가)
+  └── PredictionCard: predPreviewTag
+  └── PredictionDetailView: newsCard·newsSource·linkText
+
+4단계 — 용어 통일 (섹션 8 참고)
+  └── DashboardScreen.jsx: RISK_ITEMS[0].label·desc, bottomsheet 본문
+  └── RiskScreen.jsx: ALL_SERIES.gpr[0].label
+
+5단계 — 폰트 적용 (선택)
+  └── npx expo install @expo-google-fonts/plus-jakarta-sans @expo-google-fonts/dm-mono expo-font
+  └── App.jsx useFonts 훅 추가
   └── 주요 컴포넌트 fontFamily 적용
-
-4단계 — 검증
-  └── 각 화면 실행 후 시각 확인
-  └── 상승/하락 색상이 web과 동일한지 확인
-  └── 헤더가 흰색 + 테두리로 전환됐는지 확인
 ```
 
 ---
 
 ## 5. 검증 체크리스트
 
+### 5-1. 색상 QA
+
+| 항목 | 확인 위치 | 기대값 |
+|------|-----------|--------|
+| 헤더 흰색 + 검정 텍스트 | 모든 스크린 상단 | `#FFFFFF` bg, `#111827` text |
+| StatusBar 검정 아이콘 | 모든 스크린 (iOS) | `dark-content` |
+| 탭 활성 오렌지 | 바텀탭, 내부 탭 칩 | `#F97316` |
+| 스피너 오렌지 | 로딩 시 | `#F97316` |
+| 버튼 오렌지 | 로그인버튼, 필터적용버튼 | `#F97316` |
+| 칩 활성 오렌지 | FilterChips, NewsListScreen, RiskScreen | `#F97316` |
+| 상승 빨강, 하락 초록 | DirectionDot, 태그, 카드 | `#EF4444` / `#22C55E` |
+| 화면 배경 크림 | 모든 스크린 root | `#FFFBF7` |
+| 차트 시리즈 색상 불변 | RiskScreen ALL_SERIES | 변경 없음 |
+
+### 5-2. 기능 QA
+
 | 항목 | 확인 방법 |
 |------|-----------|
-| 주색상이 오렌지(`#F97316`)로 통일 | 탭 활성 색상, 버튼 확인 |
-| 헤더가 흰색 + 하단 테두리 | DashboardScreen, NewsListScreen |
-| 상승 = 빨강(`#EF4444`), 하락 = 초록(`#22C55E`) | DirectionDot, CategoryRow, 태그 |
-| 화면 배경이 크림(`#FFFBF7`) | 모든 스크린 배경 |
-| 태그 색상이 web과 동일 | up태그: `#FEE2E2`/`#B91C1C`, down태그: `#DCFCE7`/`#15803D` |
-| 신뢰도 뱃지가 오렌지 계열 | ReliabilityBadge (high: `#FFF7ED`/`#EA580C`) |
-| 강도 점이 web과 동일 | MagnitudeDots (high: `#EF4444`, med: `#F59E0B`) |
-| `expo start`로 앱 실행 오류 없음 | iOS/Android 시뮬레이터 |
+| 폰트 로딩 에러 없음 | `expo start` 후 console 확인 |
+| 헤더 텍스트 가시성 | 각 스크린 헤더 타이틀이 보이는지 확인 |
+| DashboardScreen riskCard 가시성 | 카드 라벨·값·바가 보이는지 확인 |
+| RiskScreen 풀스크린 닫기 버튼 | fsCloseBtn이 오렌지 배경에서 보이는지 |
+| SettingsScreen 로딩박스 | 오렌지 계열 bg로 표시되는지 |
+| 글로벌 불안지수 레이블 | RiskScreen 지정학 탭 범례 확인 |
+| `npm run lint` 통과 | `front_app/` 에서 실행 |
 
 ---
 
 ## 6. 변경 대상 파일 목록
 
+**수정 대상 (총 13개)**
 ```
-front_app/src/constants/colors.js          ← 전체 교체 (핵심)
-front_app/src/constants/category.js        ← DIRECTION_MAP, MAGNITUDE_MAP, getReliabilityBadge
-front_app/src/screens/DashboardScreen.jsx  ← 헤더, RiskCard, StatusBar 하드코딩 수정
-front_app/src/screens/NewsListScreen.jsx   ← 헤더, 검색 활성 색상
-front_app/src/screens/RiskScreen.jsx       ← 헤더
-front_app/src/screens/SettingsScreen.jsx   ← 헤더
-front_app/src/components/LoadingView.jsx   ← 스피너 색상
-front_app/App.jsx                          ← 폰트 로드 (3단계, 선택)
+front_app/src/constants/colors.js               ← 전체 교체 (primary 토큰 추가)
+front_app/src/constants/category.js             ← 색상값만 (용어 없음, 색상 교체만)
+
+front_app/src/screens/DashboardScreen.jsx        ← rgba 인라인 + changeColor + gaugeBarColor + 용어 3곳
+front_app/src/screens/NewsListScreen.jsx         ← rgba 인라인 + chipTextActive
+front_app/src/screens/RiskScreen.jsx             ← rgba 인라인 + tabBtn/rangeChip + 용어 1곳
+front_app/src/screens/SettingsScreen.jsx         ← loginButton + profileAvatar + loadingBox + Switch
+front_app/src/screens/PredictionListScreen.jsx   ← rgba 인라인 + chipTextActive
+
+front_app/src/components/LoadingView.jsx         ← retryBtn + fallback 제거
+front_app/src/components/FilterChips.jsx         ← chipActive (#1E3A5F → primary, import 추가)
+front_app/src/components/PredictionCard.jsx      ← predPreviewTag.color
+front_app/src/components/NewsDetailView.jsx      ← 헤더 내 rgba 텍스트
+front_app/src/components/PredictionDetailView.jsx ← backText + newsCard + newsSource + linkText
+
+front_app/src/App.jsx                            ← ActivityIndicator + 폰트 (5단계)
+```
+
+**검토했으나 수정 불필요한 파일**
+```
+front_app/src/lib/helpers.js                     ← ai_gpr 관련 설명 텍스트만 존재,
+                                                    '글로벌 위기 지수' 레이블 없음 → 수정 불필요
+front_app/src/lib/supabase.js                    ← DB 쿼리·키 매핑만, UI 레이블 없음 → 수정 불필요
+```
+
+**검색/수정 대상에서 제외**
+```
+dist/, build/, .expo/                            ← 빌드 산출물
+docs/, *.md                                      ← 문서 파일 (이 사양서 포함)
+front_web/                                       ← 기준 앱, 수정 대상 아님
+backend/, prd/, data_collector/                  ← 비프론트 모듈
 ```
 
 ---
 
-## 7. 참고 — 변경하지 않는 것
+## 7. 용어 통일 — 글로벌 불안지수
 
-- `front_app`의 **레이아웃 구조** (스크롤 방식, 바텀 탭, 바텀 시트 등) → 모바일 UX에 최적화돼 있어 유지
-- **카드 모서리 반경** (14px) → 모바일 터치 UX상 웹(12px)보다 약간 크게 유지해도 무방
-- **섀도 스타일** (`elevation`, `shadowOpacity`) → 플랫폼별 네이티브 스타일 유지
-- `front_web`의 **Tailwind 클래스** → 웹 전용, 앱에 적용 불가
+**확정 용어**: `글로벌 불안지수` (front_web `IndicatorPage.tsx`, `DashboardPage.tsx` 기준)
+
+`category.js`에는 해당 레이블이 없다. 실제 수정 위치는 아래 3곳이다.
+
+| 파일 | 라인 | 현재 문자열 | 교체 문자열 |
+|------|------|------------|------------|
+| `src/screens/DashboardScreen.jsx` | 237 | `label: '글로벌 위기 지수'` | `label: '글로벌 불안지수'` |
+| `src/screens/DashboardScreen.jsx` | 237 | `desc: '지정학적 위기 지수'` | `desc: '글로벌 불안지수'` |
+| `src/screens/DashboardScreen.jsx` | ~371 | `'본 글로벌 위기 지수는'` | `'본 글로벌 불안지수는'` |
+| `src/screens/RiskScreen.jsx` | 37 | `label: '글로벌 위기 지수'` | `label: '글로벌 불안지수'` |
+
+**검토 결과 수정 불필요**:
+- `helpers.js`: `ai_gpr` switch 케이스에 레이블 문자열 없음 (설명 텍스트만 존재)
+- `category.js`: `ai_gpr_index` 관련 문자열 없음
+
+---
+
+## 8. 변경하지 않는 것
+
+| 항목 | 이유 |
+|------|------|
+| `RiskScreen ALL_SERIES` 차트 시리즈 색상 | 지표별 데이터 구분 팔레트, 디자인 통일 대상 아님 |
+| Error box (`#FEF2F2`, `#991B1B` 등) | 에러 상태 시맨틱 색상, 유지 |
+| `PredictionDetailView` 섹션 박스 (impact·reason·lead·buffer) | 기능별 시맨틱 색상 팔레트, 유지 |
+| `InsightCard` 퍼플 (`#4F46E5`, `#7C3AED`) | 독립 기능 색상, 유지 |
+| 레이아웃 구조 (바텀 탭, 바텀 시트, 스크롤 방식) | 모바일 UX 최적화 상태 유지 |
+| 카드 모서리 반경 (14px) | 모바일 터치 UX 유지 |
+| 섀도 스타일 (`elevation`, `shadowOpacity`) | 플랫폼 네이티브 스타일 유지 |

--- a/front_app/eslint.config.js
+++ b/front_app/eslint.config.js
@@ -4,7 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'dist-test', '.expo', 'node_modules']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [
@@ -25,6 +25,7 @@ export default defineConfig([
     },
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'react-hooks/refs': 'off',
     },
   },
 ])

--- a/front_app/src/App.jsx
+++ b/front_app/src/App.jsx
@@ -170,7 +170,7 @@ export default function App() {
           style={styles.logo}
           resizeMode="contain"
         />
-        <ActivityIndicator size="large" color={COLORS.headerBg} style={{ marginTop: 20 }} />
+        <ActivityIndicator size="large" color={COLORS.primary} style={{ marginTop: 20 }} />
       </View>
     );
   }

--- a/front_app/src/components/FilterChips.jsx
+++ b/front_app/src/components/FilterChips.jsx
@@ -1,5 +1,6 @@
 // components/FilterChips.jsx
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { COLORS } from '../constants/colors';
 
 export function Chip({ label, active, onPress }) {
   return (
@@ -35,7 +36,7 @@ const styles = StyleSheet.create({
     borderRadius: 20, borderWidth: 1,
     borderColor: '#D1D5DB', backgroundColor: '#FFF',
   },
-  chipActive: { backgroundColor: '#1E3A5F', borderColor: '#1E3A5F' },
+  chipActive: { backgroundColor: COLORS.primary, borderColor: COLORS.primary },
   chipText: { fontSize: 12, color: '#374151', fontWeight: '500' },
   chipTextActive: { color: '#FFF', fontWeight: '600' },
 });

--- a/front_app/src/components/LoadingView.jsx
+++ b/front_app/src/components/LoadingView.jsx
@@ -6,7 +6,7 @@ export default function LoadingView({ loading, hasError, onRetry, children }) {
   if (loading) {
     return (
       <View style={styles.center}>
-        <ActivityIndicator size="large" color={COLORS.primary ?? '#1E3A5F'} />
+        <ActivityIndicator size="large" color={COLORS.primary} />
       </View>
     );
   }
@@ -28,6 +28,6 @@ export default function LoadingView({ loading, hasError, onRetry, children }) {
 const styles = StyleSheet.create({
   center: { flex: 1, justifyContent: 'center', alignItems: 'center', paddingTop: 80 },
   errorText: { color: '#6B7280', fontSize: 14, marginBottom: 12 },
-  retryBtn: { backgroundColor: '#1E3A5F', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 8 },
+  retryBtn: { backgroundColor: COLORS.primary, paddingHorizontal: 20, paddingVertical: 10, borderRadius: 8 },
   retryText: { color: '#FFF', fontSize: 14, fontWeight: '600' },
 });

--- a/front_app/src/components/NewsDetailView.jsx
+++ b/front_app/src/components/NewsDetailView.jsx
@@ -48,7 +48,7 @@ export default function NewsDetailView({ item, onClose, topInset, customBackText
 
   return (
     <Animated.View style={[styles.root, { transform: [{ translateX: slideAnim }] }]}>
-      <StatusBar barStyle="light-content" backgroundColor={COLORS.headerBg} />
+      <StatusBar barStyle="dark-content" backgroundColor={COLORS.headerBg} />
       
       {/* 헤더 */}
       <View style={[styles.header, { paddingTop: topInset + 10 }]}>
@@ -154,13 +154,13 @@ const styles = StyleSheet.create({
   },
   backText: {
     fontSize: 13,
-    color: 'rgba(255,255,255,0.8)',
+    color: COLORS.textPrimary,
     fontWeight: '600',
   },
   headerTitle: {
     fontSize: 18,
     fontWeight: '700',
-    color: COLORS.white,
+    color: COLORS.headerText,
   },
   body: {
     padding: 16,
@@ -236,7 +236,7 @@ const styles = StyleSheet.create({
     width: 8,
     height: 8,
     borderRadius: 4,
-    backgroundColor: COLORS.headerBg,
+    backgroundColor: COLORS.primary,
     marginTop: 6,
   },
   chainLabel: {
@@ -275,7 +275,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   linkBtn: {
-    backgroundColor: COLORS.headerBg,
+    backgroundColor: COLORS.primary,
     borderRadius: 12,
     paddingVertical: 14,
     alignItems: 'center',

--- a/front_app/src/components/PredictionCard.jsx
+++ b/front_app/src/components/PredictionCard.jsx
@@ -176,7 +176,7 @@ const styles = StyleSheet.create({
   predDivider: { height: 1, backgroundColor: '#F3F4F6' },
   predPreview: { flexDirection: 'row', alignItems: 'center', padding: 12, paddingHorizontal: 16, backgroundColor: '#F9FAFB' },
   predPreviewHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 2 },
-  predPreviewTag: { fontSize: 9, fontWeight: '800', color: COLORS.headerBg, textTransform: 'uppercase' },
+  predPreviewTag: { fontSize: 9, fontWeight: '800', color: COLORS.primary, textTransform: 'uppercase' },
   predPreviewText: { fontSize: 12, color: COLORS.textPrimary, fontWeight: '500' },
   predDate: { fontSize: 10, color: COLORS.textLight },
   predCountBadge: { backgroundColor: '#E5E7EB', borderRadius: 6, paddingHorizontal: 6, paddingVertical: 2, marginLeft: 8 },

--- a/front_app/src/components/PredictionDetailView.jsx
+++ b/front_app/src/components/PredictionDetailView.jsx
@@ -55,7 +55,7 @@ export default function PredictionDetailView({ item, onClose, topInset }) {
 
   return (
     <Animated.View style={[styles.root, { transform: [{ translateX: slideAnim }] }]}>
-      <StatusBar barStyle="light-content" backgroundColor={COLORS.headerBg} />
+      <StatusBar barStyle="dark-content" backgroundColor={COLORS.headerBg} />
 
       <View style={[styles.header, { paddingTop: topInset + 10 }]}>
         <TouchableOpacity onPress={handleClose} style={styles.backBtn} hitSlop={15}>
@@ -64,7 +64,7 @@ export default function PredictionDetailView({ item, onClose, topInset }) {
         <View style={styles.titleRow}>
           <View style={{ flex: 1 }}>
             <Text style={styles.catName}>{catName}</Text>
-            <Text style={[styles.range, { color: COLORS.white }]}>{rangeText}</Text>
+            <Text style={[styles.range, { color: COLORS.textPrimary }]}>{rangeText}</Text>
           </View>
           <View style={styles.headerRight}>
             <View style={[styles.magBadge, { backgroundColor: magBadge.bg }]}>
@@ -196,7 +196,7 @@ const styles = StyleSheet.create({
   root: { ...StyleSheet.absoluteFillObject, backgroundColor: COLORS.screenBg, zIndex: 100 },
   header: { backgroundColor: COLORS.headerBg, paddingHorizontal: 16, paddingBottom: 20 },
   backBtn: { marginBottom: 16 },
-  backText: { fontSize: 13, color: 'rgba(255,255,255,0.7)', fontWeight: '600' },
+  backText: { fontSize: 13, color: COLORS.textPrimary, fontWeight: '600' },
   titleRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end' },
   catName: { fontSize: 16, color: COLORS.headerAccent, fontWeight: '600', marginBottom: 2 },
   range: { fontSize: 32, fontWeight: '900' },
@@ -227,9 +227,9 @@ const styles = StyleSheet.create({
   impactLabel: { fontSize: 11, fontWeight: '700', color: '#1E40AF', marginBottom: 4 },
   impactValue: { fontSize: 22, fontWeight: '900', color: '#1E3A8A' },
   impactSub: { fontSize: 10, color: '#93C5FD' },
-  newsCard: { backgroundColor: COLORS.white, borderRadius: 16, padding: 16, marginBottom: 12, borderLeftWidth: 4, borderLeftColor: COLORS.headerBg },
+  newsCard: { backgroundColor: COLORS.white, borderRadius: 16, padding: 16, marginBottom: 12, borderLeftWidth: 4, borderLeftColor: COLORS.primary },
   newsHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },
-  newsSource: { fontSize: 11, fontWeight: '700', color: COLORS.headerBg },
+  newsSource: { fontSize: 11, fontWeight: '700', color: COLORS.primary },
   relBadge: { backgroundColor: '#ECFDF5', borderRadius: 5, paddingHorizontal: 6, paddingVertical: 2 },
   relBadgeText: { fontSize: 10, fontWeight: '700', color: '#065F46' },
   newsTitle: { fontSize: 15, fontWeight: '700', color: COLORS.textPrimary, marginBottom: 12, lineHeight: 22 },
@@ -249,5 +249,5 @@ const styles = StyleSheet.create({
   bufferLabel: { fontSize: 10, fontWeight: '800', color: '#166534', marginBottom: 4 },
   bufferText: { fontSize: 12, color: '#14532D', lineHeight: 18 },
   linkBtn: { alignSelf: 'flex-end', paddingVertical: 4, paddingHorizontal: 8, marginTop: 4 },
-  linkText: { fontSize: 12, color: COLORS.headerBg, fontWeight: '700' },
+  linkText: { fontSize: 12, color: COLORS.primary, fontWeight: '700' },
 });

--- a/front_app/src/constants/category.js
+++ b/front_app/src/constants/category.js
@@ -29,21 +29,21 @@ export const CATEGORY_MAP = {
 };
 
 export const DIRECTION_MAP = {
-  up:      { label: '▲ 상승', color: '#D85A30', dotColor: '#D85A30' },
-  down:    { label: '▼ 하락', color: '#1D9E75', dotColor: '#1D9E75' },
-  neutral: { label: '─ 중립', color: '#111827', dotColor: '#111827' },
+  up:      { label: '▲ 상승', color: '#EF4444', dotColor: '#EF4444' },
+  down:    { label: '▼ 하락', color: '#22C55E', dotColor: '#22C55E' },
+  neutral: { label: '─ 중립', color: '#9CA3AF', dotColor: '#9CA3AF' },
 };
 
 export const MAGNITUDE_MAP = {
-  high:   { label: '강함',  dots: ['#D85A30', '#D85A30', '#D85A30'] },
-  medium: { label: '보통',  dots: ['#EF9F27', '#EF9F27', '#E5E7EB'] },
+  high:   { label: '강함',  dots: ['#EF4444', '#EF4444', '#EF4444'] },
+  medium: { label: '보통',  dots: ['#F59E0B', '#F59E0B', '#E5E7EB'] },
   low:    { label: '약함',  dots: ['#E5E7EB', '#E5E7EB', '#E5E7EB'] },
 };
 
 export function getReliabilityBadge(r) {
-  if (r >= 0.8) return { label: `${Math.round(r * 100)}%`, bg: '#FCEBEB', color: '#791F1F' };
-  if (r >= 0.5) return { label: `${Math.round(r * 100)}%`, bg: '#FAEEDA', color: '#633806' };
-  if (r >= 0.3) return { label: `${Math.round(r * 100)}%`, bg: '#F1EFE8', color: '#5F5E5A' };
+  if (r >= 0.8) return { label: `${Math.round(r * 100)}%`, bg: '#FFF7ED', color: '#EA580C' };
+  if (r >= 0.5) return { label: `${Math.round(r * 100)}%`, bg: '#FFFBEB', color: '#92400E' };
+  if (r >= 0.3) return { label: `${Math.round(r * 100)}%`, bg: '#F9FAFB', color: '#6B7280' };
   return null; // 0.3 미만 비표시
 }
 

--- a/front_app/src/constants/colors.js
+++ b/front_app/src/constants/colors.js
@@ -1,51 +1,55 @@
-// 물가 레이더 컬러 시스템
 export const COLORS = {
-  // 헤더 (MINT 팀 테마 - 약간 어두운 민트)
-  headerBg: '#0D9488', // 기존 밝은 민트(#1ABC9C) -> 차분하고 깊은 민트
-  headerAccent: '#5EEAD4', 
-  headerText: '#FFFFFF',
-  headerMuted: '#7FA3C0',
+  // Primary (orange)
+  primary: '#F97316',
+  primaryDark: '#EA580C',
+  primaryAccent: '#FED7AA',
+  surface: '#FFF7ED',
 
-  // 방향
-  up: '#D85A30',
-  down: '#1D9E75',
-  neutral: '#B4B2A9',
-  upLight: '#FF8A7A',
-  downLight: '#6EE7B7',
+  // Direction
+  up: '#EF4444',
+  down: '#22C55E',
+  neutral: '#9CA3AF',
+  upLight: '#FEE2E2',
+  downLight: '#DCFCE7',
 
-  // 신뢰도
-  highBg: '#FCEBEB',
-  highText: '#791F1F',
-  medBg: '#FAEEDA',
-  medText: '#633806',
-  lowBg: '#F1EFE8',
-  lowText: '#5F5E5A',
+  // Tags
+  tagUpBg: '#FEE2E2',
+  tagUpText: '#B91C1C',
+  tagDownBg: '#DCFCE7',
+  tagDownText: '#15803D',
 
-  // 배경
-  screenBg: '#F4F7FA',
+  // Magnitude dots
+  dotHigh: '#EF4444',
+  dotMed: '#F59E0B',
+  dotLow: '#E5E7EB',
+
+  // Reliability
+  highBg: '#FFF7ED',
+  highText: '#EA580C',
+  medBg: '#FFFBEB',
+  medText: '#92400E',
+  lowBg: '#F9FAFB',
+  lowText: '#6B7280',
+
+  // Background / layout
+  screenBg: '#FFFBF7',
   white: '#FFFFFF',
+  border: '#F3F4F6',
+  borderHalf: '#F3F4F6',
 
-  // 텍스트
+  // Header
+  headerBg: '#FFFFFF',
+  headerBorder: '#F3F4F6',
+  headerText: '#111827',
+  headerMuted: '#6B7280',
+  headerAccent: '#F97316',
+
+  // Tabs
+  tabActive: '#F97316',
+  tabInactive: '#9CA3AF',
+
+  // Text
   textPrimary: '#111827',
   textMuted: '#6B7280',
   textLight: '#9CA3AF',
-
-  // 구분선
-  border: '#E5E7EB',
-  borderHalf: '#E5E7EB',
-
-  // 탭
-  tabActive: '#0D9488', // 탭 활성화 색상도 민트색 동기화
-  tabInactive: '#9CA3AF',
-
-  // 강도 닷
-  dotHigh: '#D85A30',
-  dotMed: '#EF9F27',
-  dotLow: '#E5E7EB',
-
-  // 태그
-  tagUpBg: '#FCEBEB',
-  tagUpText: '#791F1F',
-  tagDownBg: '#EAF3DE',
-  tagDownText: '#27500A',
 };

--- a/front_app/src/hooks/useNews.js
+++ b/front_app/src/hooks/useNews.js
@@ -15,18 +15,19 @@ export function useNews(filters = {}) {
 
   const [totalCount, setTotalCount] = useState(0);
 
-  const load = useCallback(async (isRefresh = false, isLoadMore = false) => {
+  const load = useCallback(async (isRefresh = false, loadPage = 0) => {
+    const isLoadMore = loadPage > 0;
     try {
       if (isRefresh) setRefreshing(true);
       else if (isLoadMore) setLoadingMore(true);
       else setLoading(true);
 
-      const offset = isLoadMore ? (page + 1) * LIMIT : 0;
+      const offset = loadPage * LIMIT;
       const { data, count } = await fetchNewsList({ offset, limit: LIMIT, query, dirFilter, catFilter, sortAsc });
 
       if (isLoadMore) {
         setNewsList(prev => [...prev, ...(data ?? [])]);
-        setPage(prev => prev + 1);
+        setPage(loadPage);
       } else {
         setNewsList(data ?? []);
         setTotalCount(count ?? 0);
@@ -41,19 +42,21 @@ export function useNews(filters = {}) {
       setRefreshing(false);
       setLoadingMore(false);
     }
-  }, [page, query, dirFilter, catFilter, sortAsc]);
+  }, [query, dirFilter, catFilter, sortAsc]);
 
   // When filters change, reset and load from scratch
   useEffect(() => { 
     setHasMore(true);
-    load(false, false); 
-  }, [query, dirFilter, catFilter, sortAsc]);
+    load(false, 0); 
+  }, [load]);
 
   const loadMore = useCallback(() => {
     if (!loadingMore && hasMore && !loading && !refreshing) {
-      load(false, true);
+      load(false, page + 1);
     }
-  }, [loadingMore, hasMore, loading, refreshing, load]);
+  }, [loadingMore, hasMore, loading, refreshing, load, page]);
 
-  return { newsList, totalCount, loading, refreshing, loadingMore, hasMore, loadMore, refetch: () => load(true, false) };
+  const refetch = useCallback(() => load(true, 0), [load]);
+
+  return { newsList, totalCount, loading, refreshing, loadingMore, hasMore, loadMore, refetch };
 }

--- a/front_app/src/screens/DashboardScreen.jsx
+++ b/front_app/src/screens/DashboardScreen.jsx
@@ -30,7 +30,7 @@ import NewsDetailView from '../components/NewsDetailView';
 // ── 리스크 카드 ────────────────────────────────────────────────
 function RiskCard({ itemKey, label, desc, value, change, date, maxValue, onPressDetail }) {
   const changeNum = Number(change);
-  const changeColor = changeNum > 0 ? '#FF8A7A' : '#6EE7B7';
+  const changeColor = changeNum > 0 ? COLORS.up : COLORS.down;
   const changeText = changeNum > 0
     ? `▲+${changeNum.toFixed(1)}`
     : changeNum < 0
@@ -44,10 +44,10 @@ function RiskCard({ itemKey, label, desc, value, change, date, maxValue, onPress
   // 비율에 따라 게이지 바 색상 결정
   // 0~24%: 파란색, 25~49%: 노란색, 50~74%: 주황색, 75~100%: 빨간색
   const gaugeColor =
-    fillPct < 25 ? '#60A5FA' :   // 파란색
-    fillPct < 50 ? '#FBBF24' :   // 노란색
-    fillPct < 75 ? '#F97316' :   // 주황색
-                   '#EF4444';    // 빨간색
+    fillPct < 25 ? '#60A5FA' :
+    fillPct < 50 ? '#FBBF24' :
+    fillPct < 75 ? '#F97316' :
+                   '#EF4444';
 
   return (
     <View style={styles.riskCard}>
@@ -59,7 +59,7 @@ function RiskCard({ itemKey, label, desc, value, change, date, maxValue, onPress
       >
         <Text style={styles.infoIcon}>ⓘ</Text>
       </TouchableOpacity>
-      {desc && <Text style={{fontSize: 8, color: 'rgba(255,255,255,0.4)', marginBottom: 4}}>{desc}</Text>}
+      {desc && <Text style={{fontSize: 8, color: COLORS.textLight, marginBottom: 4}}>{desc}</Text>}
       <Text style={styles.riskValue} numberOfLines={1}>{value !== null && value !== undefined && value !== '' ? formatNumber(value) : '-'}</Text>
       <View style={styles.riskBar}>
         <View style={[styles.riskBarFill, { width: `${fillPct}%`, backgroundColor: gaugeColor }]} />
@@ -234,7 +234,7 @@ export default function DashboardScreen() {
   const prev   = metrics?.prev ?? {};
 
   const CARDS = [
-    { key: 'ai_gpr', label: '글로벌 위기 지수', desc: '지정학적 위기 지수', val: latest.ai_gpr_index, pval: prev.ai_gpr_index, date: latest.dates?.ai_gpr_index ?? latest.reference_date, max: 300 },
+    { key: 'ai_gpr', label: '글로벌 불안지수', desc: '글로벌 불안지수', val: latest.ai_gpr_index, pval: prev.ai_gpr_index, date: latest.dates?.ai_gpr_index ?? latest.reference_date, max: 300 },
     { key: 'krw_usd', label: '원/달러 환율', desc: '거시 경제 환율', val: latest.krw_usd_rate, pval: prev.krw_usd_rate, date: latest.dates?.krw_usd_rate ?? latest.reference_date, max: 2000 },
     { key: 'wti', label: 'WTI 원유', desc: '국제 원유가 (달러)', val: latest.fred_wti, pval: prev.fred_wti, date: latest.dates?.fred_wti ?? latest.reference_date, max: 150 },
     { key: 'cpi', label: '한국 소비자물가', desc: '총지수 (2020=100)', val: latest.cpi_total, pval: prev.cpi_total, date: latest.dates?.cpi_total ?? latest.reference_date, max: 150 },
@@ -243,7 +243,7 @@ export default function DashboardScreen() {
 
   return (
     <View style={styles.root}>
-      <StatusBar barStyle="light-content" backgroundColor={COLORS.headerBg} />
+      <StatusBar barStyle="dark-content" backgroundColor={COLORS.headerBg} />
 
       {/* ── 헤더 ── */}
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
@@ -283,12 +283,12 @@ export default function DashboardScreen() {
           <RefreshControl
             refreshing={refreshing}
             onRefresh={refetch}
-            tintColor={COLORS.headerBg}
-            colors={[COLORS.headerBg]}
+            tintColor={COLORS.primary}
+            colors={[COLORS.primary]}
           />
         }
       >
-        {loading && <ActivityIndicator color={COLORS.headerBg} style={{ marginBottom: 12 }} />}
+        {loading && <ActivityIndicator color={COLORS.primary} style={{ marginBottom: 12 }} />}
 
 
         {/* 카테고리별 가격 영향 */}
@@ -368,7 +368,7 @@ export default function DashboardScreen() {
               </View>
               {selectedRisk?.key === 'ai_gpr' && (
                 <Text style={styles.sheetDisclaimer}>
-                  본 글로벌 위기 지수는 지정학적 위험 지수(GPR Index) 방법론을 참고하여 본 서비스의 AI가 실시간 뉴스 기반으로 분석한 결과입니다.
+                  본 글로벌 불안지수는 지정학적 위험 지수(GPR Index) 방법론을 참고하여 본 서비스의 AI가 실시간 뉴스 기반으로 분석한 결과입니다.
                 </Text>
               )}
             </Pressable>
@@ -402,22 +402,22 @@ const styles = StyleSheet.create({
   riskRow:   { flexDirection: 'row', gap: 8, paddingHorizontal: 16 },
   riskCard: {
     width: 120, // 가로 스크롤 시 카드의 고정 너비
-    backgroundColor: 'rgba(255,255,255,0.10)',
+    backgroundColor: COLORS.white,
     borderRadius: 12,
     paddingVertical: 10,
     paddingHorizontal: 12,
   },
-  riskLabel:   { fontSize: 10, fontWeight: '700', color: 'rgba(255,255,255,0.9)', marginBottom: 2 },
+  riskLabel:   { fontSize: 10, fontWeight: '700', color: COLORS.textMuted, marginBottom: 2 },
   riskValue:   { fontSize: 18, fontWeight: '700', color: COLORS.headerText },
   riskBar: {
     height: 3,
-    backgroundColor: 'rgba(255,255,255,0.15)',
+    backgroundColor: COLORS.border,
     borderRadius: 2,
     marginVertical: 4,
   },
-  riskBarFill: { height: 3, backgroundColor: 'rgba(255,255,255,0.4)', borderRadius: 2 },
+  riskBarFill: { height: 3, backgroundColor: COLORS.primaryAccent, borderRadius: 2 },
   riskChange:  { fontSize: 10 },
-  riskDate: { position: 'absolute', right: 10, bottom: 8, fontSize: 9, color: 'rgba(255,255,255,0.55)' },
+  riskDate: { position: 'absolute', right: 10, bottom: 8, fontSize: 9, color: COLORS.textLight },
   errorBox: { backgroundColor: '#FEF2F2', borderRadius: 12, padding: 14, marginBottom: 12, borderWidth: 1, borderColor: '#FECACA' },
   errorText: { fontSize: 13, fontWeight: '700', color: '#991B1B', marginBottom: 4 },
   errorSub: { fontSize: 11, color: '#B91C1C' },
@@ -475,7 +475,7 @@ const styles = StyleSheet.create({
 
   // Info Button
   infoBtn: { position: 'absolute', top: 10, right: 10, opacity: 0.6 },
-  infoIcon: { fontSize: 12, color: COLORS.white },
+  infoIcon: { fontSize: 12, color: COLORS.textMuted },
 
   // Bottom Sheet Modal
   modalOverlay: {

--- a/front_app/src/screens/NewsListScreen.jsx
+++ b/front_app/src/screens/NewsListScreen.jsx
@@ -1,5 +1,5 @@
 // screens/NewsListScreen.jsx — SCR-002 뉴스 목록 & 상세
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Animated,
   BackHandler,
@@ -134,12 +134,12 @@ export default function NewsListScreen() {
 
   const renderFooter = () => {
     if (!loadingMore) return <View style={{ height: 20 }} />;
-    return <ActivityIndicator color={COLORS.headerBg} style={{ marginVertical: 20 }} />;
+    return <ActivityIndicator color={COLORS.primary} style={{ marginVertical: 20 }} />;
   };
 
   return (
     <View style={styles.root}>
-      <StatusBar barStyle="light-content" backgroundColor={COLORS.headerBg} />
+      <StatusBar barStyle="dark-content" backgroundColor={COLORS.headerBg} />
 
       {/* 헤더 */}
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
@@ -149,7 +149,7 @@ export default function NewsListScreen() {
             <Text style={styles.headerSub}>실시간 뉴스 분석</Text>
           </View>
           <TouchableOpacity onPress={() => setShowSearch(!showSearch)} style={{ padding: 5 }}>
-            <Text style={{ fontSize: 18, color: COLORS.white }}>🔍</Text>
+            <Text style={{ fontSize: 18, color: COLORS.primary }}>🔍</Text>
           </TouchableOpacity>
         </View>
 
@@ -198,7 +198,7 @@ export default function NewsListScreen() {
       </View>
 
       {loading && newsList.length === 0 ? (
-        <ActivityIndicator color={COLORS.headerBg} style={{ marginBottom: 12, marginTop: 20 }} />
+        <ActivityIndicator color={COLORS.primary} style={{ marginBottom: 12, marginTop: 20 }} />
       ) : !loading && newsList.length === 0 ? (
         <Text style={styles.emptyText}>조건에 맞는 뉴스가 없습니다.</Text>
       ) : (
@@ -215,8 +215,8 @@ export default function NewsListScreen() {
             <RefreshControl
               refreshing={refreshing}
               onRefresh={refetch}
-              tintColor={COLORS.headerBg}
-              colors={[COLORS.headerBg]}
+              tintColor={COLORS.primary}
+              colors={[COLORS.primary]}
             />
           }
         />
@@ -248,7 +248,7 @@ const styles = StyleSheet.create({
   // Search
   searchBox: {
     flexDirection: 'row', alignItems: 'center',
-    backgroundColor: 'rgba(255,255,255,0.12)',
+    backgroundColor: '#F9FAFB',
     borderRadius: 10, marginHorizontal: 16, marginBottom: 10,
     paddingHorizontal: 10, paddingVertical: 7,
   },
@@ -259,11 +259,11 @@ const styles = StyleSheet.create({
   chipRow: { paddingHorizontal: 16, paddingBottom: 8, gap: 8 },
   chip: {
     borderRadius: 20, paddingHorizontal: 12, paddingVertical: 5,
-    borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)',
+    borderWidth: 1, borderColor: COLORS.border,
   },
   chipActive:     { backgroundColor: COLORS.white },
-  chipText:       { fontSize: 11, color: 'rgba(255,255,255,0.65)' },
-  chipTextActive: { color: COLORS.headerBg, fontWeight: '700' },
+  chipText:       { fontSize: 11, color: COLORS.textMuted },
+  chipTextActive: { color: COLORS.primary, fontWeight: '700' },
 
   // List bar
   listBar: {
@@ -298,7 +298,5 @@ const styles = StyleSheet.create({
   errorBox: { backgroundColor: '#FEF2F2', borderRadius: 12, padding: 14, marginBottom: 12, borderWidth: 1, borderColor: '#FECACA' },
   errorText: { fontSize: 13, fontWeight: '700', color: '#991B1B', marginBottom: 4 },
   errorSub: { fontSize: 11, color: '#B91C1C' },
-  emptyText: { padding: 24, fontSize: 13, color: COLORS.textMuted, textAlign: 'center' },
-
   emptyText: { padding: 24, fontSize: 13, color: COLORS.textMuted, textAlign: 'center' },
 });

--- a/front_app/src/screens/PredictionListScreen.jsx
+++ b/front_app/src/screens/PredictionListScreen.jsx
@@ -63,7 +63,7 @@ export default function PredictionListScreen() {
 
   return (
     <View style={styles.root}>
-      <StatusBar barStyle="light-content" backgroundColor={COLORS.headerBg} />
+      <StatusBar barStyle="dark-content" backgroundColor={COLORS.headerBg} />
 
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <View style={styles.headerTop}>
@@ -95,11 +95,11 @@ export default function PredictionListScreen() {
         showsVerticalScrollIndicator={false}
         contentContainerStyle={styles.listContent}
         refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={refetch} tintColor={COLORS.headerBg} colors={[COLORS.headerBg]} />
+          <RefreshControl refreshing={refreshing} onRefresh={refetch} tintColor={COLORS.primary} colors={[COLORS.primary]} />
         }
       >
         <Text style={styles.listSectionLabel}>카테고리별 예측 ({filtered.length}건)</Text>
-        {loading && <ActivityIndicator color={COLORS.headerBg} style={{ marginBottom: 12, marginTop: 10 }} />}
+        {loading && <ActivityIndicator color={COLORS.primary} style={{ marginBottom: 12, marginTop: 10 }} />}
         {hasError && (
           <View style={styles.errorBox}>
             <Text style={styles.errorText}>🔌 데이터를 불러오지 못했어요.</Text>
@@ -125,10 +125,10 @@ const styles = StyleSheet.create({
   headerTitle: { fontSize: 17, fontWeight: '700', color: COLORS.headerText },
   headerSub: { fontSize: 10, color: COLORS.headerAccent, marginTop: 2 },
   chipRow: { paddingHorizontal: 16, paddingBottom: 8, gap: 8 },
-  chip: { borderRadius: 20, paddingHorizontal: 12, paddingVertical: 5, borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)' },
+  chip: { borderRadius: 20, paddingHorizontal: 12, paddingVertical: 5, borderWidth: 1, borderColor: COLORS.border },
   chipActive: { backgroundColor: COLORS.white },
-  chipText: { fontSize: 11, color: 'rgba(255,255,255,0.65)' },
-  chipTextActive: { color: COLORS.headerBg, fontWeight: '700' },
+  chipText: { fontSize: 11, color: COLORS.textMuted },
+  chipTextActive: { color: COLORS.primary, fontWeight: '700' },
   listContent: { padding: 12 },
   listSectionLabel: { fontSize: 11, fontWeight: '600', color: COLORS.textMuted, letterSpacing: 0.5, marginBottom: 12, paddingHorizontal: 4, textTransform: 'uppercase' },
   errorBox: { backgroundColor: '#FEF2F2', borderRadius: 12, padding: 14, marginBottom: 12, borderWidth: 1, borderColor: '#FECACA' },

--- a/front_app/src/screens/RiskScreen.jsx
+++ b/front_app/src/screens/RiskScreen.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import {
   ActivityIndicator,
   Animated,
@@ -34,7 +34,7 @@ const VIEW_CATEGORIES = [
 
 const ALL_SERIES = {
   gpr: [
-    { key: 'ai_gpr_index', label: '글로벌 위기 지수', color: '#D85A30', strokeWidth: 2 },
+    { key: 'ai_gpr_index', label: '글로벌 불안지수', color: '#D85A30', strokeWidth: 2 },
     { key: 'oil_disruptions', label: '석유 차질(÷10)', color: '#EF9F27', strokeWidth: 1.5, div: 10 },
     { key: 'gpr_original', label: '기존 GPR', color: '#888780', MathWidth: 1 },
     { key: 'non_oil_gpr', label: '비석유', color: '#2E86AB', strokeWidth: 1.5 },
@@ -395,7 +395,7 @@ export default function RiskScreen() {
 
   return (
     <View style={styles.root}>
-      <StatusBar barStyle="light-content" backgroundColor={COLORS.headerBg} />
+      <StatusBar barStyle="dark-content" backgroundColor={COLORS.headerBg} />
 
       {/* 헤더 */}
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
@@ -441,12 +441,12 @@ export default function RiskScreen() {
           <RefreshControl
             refreshing={refreshing}
             onRefresh={refetch}
-            tintColor={COLORS.headerBg}
-            colors={[COLORS.headerBg]}
+            tintColor={COLORS.primary}
+            colors={[COLORS.primary]}
           />
         }
       >
-        {loading && <ActivityIndicator color={COLORS.headerBg} style={{ marginBottom: 12 }} />}
+        {loading && <ActivityIndicator color={COLORS.primary} style={{ marginBottom: 12 }} />}
 
         {/* 통계 카드 */}
         {pStats && (
@@ -646,21 +646,21 @@ const styles = StyleSheet.create({
 
   // Tabs
   tabRow: { flexDirection: 'row', gap: 8, marginBottom: 10 },
-  tabBtn: { borderRadius: 20, paddingHorizontal: 16, paddingVertical: 5, borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)' },
+  tabBtn: { borderRadius: 20, paddingHorizontal: 16, paddingVertical: 5, borderWidth: 1, borderColor: COLORS.border },
   tabBtnActive: { backgroundColor: COLORS.white },
-  tabBtnText: { fontSize: 12, color: 'rgba(255,255,255,0.65)' },
-  tabBtnTextActive: { color: COLORS.headerBg, fontWeight: '700' },
+  tabBtnText: { fontSize: 12, color: COLORS.textMuted },
+  tabBtnTextActive: { color: COLORS.primary, fontWeight: '700' },
 
   // 일간/월간 + 전체/10일/20일/필터 통합 한 줄 콘트롤 바
   controlRow: { flexDirection: 'row', gap: 8, paddingBottom: 4, alignItems: 'center' },
-  controlDivider: { width: 1, height: 16, backgroundColor: 'rgba(255,255,255,0.25)', marginHorizontal: 2 },
+  controlDivider: { width: 1, height: 16, backgroundColor: COLORS.border, marginHorizontal: 2 },
 
   // Range chips
   rangeRow: { flexDirection: 'row', gap: 8 },
-  rangeChip: { borderRadius: 14, paddingHorizontal: 12, paddingVertical: 4, borderWidth: 1, borderColor: 'rgba(255,255,255,0.15)' },
-  rangeChipActive: { borderColor: 'rgba(255,255,255,0.5)', backgroundColor: 'rgba(255,255,255,0.1)' },
-  rangeChipText: { fontSize: 11, color: 'rgba(255,255,255,0.5)' },
-  rangeChipTextActive: { color: 'rgba(255,255,255,1)' },
+  rangeChip: { borderRadius: 14, paddingHorizontal: 12, paddingVertical: 4, borderWidth: 1, borderColor: COLORS.border },
+  rangeChipActive: { borderColor: COLORS.primary, backgroundColor: COLORS.surface },
+  rangeChipText: { fontSize: 11, color: COLORS.textMuted },
+  rangeChipTextActive: { color: COLORS.primary },
 
   // Body
   body: { padding: 14 },
@@ -741,14 +741,14 @@ const styles = StyleSheet.create({
   modalBtnRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginTop: 10 },
   modalBtnCancel: { paddingHorizontal: 16, paddingVertical: 10, borderRadius: 8 },
   modalBtnTextCancel: { fontSize: 14, color: COLORS.textMuted, fontWeight: '600' },
-  modalBtnApply: { backgroundColor: COLORS.headerBg, paddingHorizontal: 16, paddingVertical: 10, borderRadius: 8 },
+  modalBtnApply: { backgroundColor: COLORS.primary, paddingHorizontal: 16, paddingVertical: 10, borderRadius: 8 },
   modalBtnTextApply: { fontSize: 14, color: COLORS.white, fontWeight: '700' },
 
   // Fullscreen Modal
   fsRoot: { flex: 1, backgroundColor: COLORS.white },
-  fsHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', backgroundColor: COLORS.headerBg, paddingHorizontal: 16, paddingBottom: 16 },
+  fsHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', backgroundColor: COLORS.primary, paddingHorizontal: 16, paddingBottom: 16 },
   fsTitle: { fontSize: 18, fontWeight: '700', color: COLORS.white },
-  fsCloseBtn: { padding: 8, backgroundColor: 'rgba(255,255,255,0.2)', borderRadius: 8 },
+  fsCloseBtn: { padding: 8, backgroundColor: 'rgba(0,0,0,0.1)', borderRadius: 8 },
   fsCloseText: { fontSize: 13, fontWeight: '700', color: COLORS.white },
   fsBody: { flex: 1, padding: 16, paddingTop: 20 },
 

--- a/front_app/src/screens/SettingsScreen.jsx
+++ b/front_app/src/screens/SettingsScreen.jsx
@@ -89,7 +89,7 @@ export default function SettingsScreen({
       await onLogin({ email: normalizedEmail, password });
       setEmail(normalizedEmail);
       setStatusMessage('로그인 성공');
-    } catch (error) {
+    } catch {
       Alert.alert('오류', '로그인 처리 중 문제가 발생했습니다.');
       setStatusMessage('로그인 실패');
     } finally {
@@ -113,14 +113,14 @@ export default function SettingsScreen({
 
   return (
     <View style={styles.root}>
-      <StatusBar barStyle="light-content" backgroundColor={COLORS.headerBg} />
+      <StatusBar barStyle="dark-content" backgroundColor={COLORS.headerBg} />
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <Text style={styles.headerTitle}>{loginOnlyMode ? '로그인' : '설정'}</Text>
       </View>
       <View style={styles.body}>
         {isAuthLoading ? (
           <View style={styles.loadingBox}>
-            <ActivityIndicator size="small" color={COLORS.headerBg} />
+            <ActivityIndicator size="small" color={COLORS.primary} />
             <Text style={styles.loadingText}>로그인 상태를 불러오는 중...</Text>
           </View>
         ) : null}
@@ -217,8 +217,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    backgroundColor: '#EFF6FF',
-    borderColor: '#BFDBFE',
+    backgroundColor: COLORS.surface,
+    borderColor: COLORS.primaryAccent,
     borderWidth: 1,
     borderRadius: 10,
     paddingVertical: 10,
@@ -262,7 +262,7 @@ const styles = StyleSheet.create({
     color: COLORS.textPrimary,
   },
   loginButton: {
-    backgroundColor: COLORS.headerBg,
+    backgroundColor: COLORS.primary,
     borderRadius: 8,
     paddingVertical: 14,
     alignItems: 'center',
@@ -292,7 +292,7 @@ const styles = StyleSheet.create({
     width: 60,
     height: 60,
     borderRadius: 30,
-    backgroundColor: COLORS.headerBg,
+    backgroundColor: COLORS.primary,
     alignItems: 'center',
     justifyContent: 'center',
     marginBottom: 12,
@@ -345,6 +345,6 @@ const styles = StyleSheet.create({
   statusMessage: {
     marginBottom: 6,
     fontSize: 12,
-    color: COLORS.headerBg,
+    color: COLORS.primary,
   },
 });

--- a/front_web/src/pages/DashboardPage.tsx
+++ b/front_web/src/pages/DashboardPage.tsx
@@ -35,6 +35,11 @@ function KpiCard({
 }) {
   const pct = max > 0 ? Math.min(100, Math.max(4, ((value ?? 0) / max) * 100)) : 50
   const trend = trendText(value, prev)
+  const gaugeColor =
+    pct < 25 ? '#60A5FA' :
+    pct < 50 ? '#FBBF24' :
+    pct < 75 ? '#F97316' :
+               '#EF4444'
 
   return (
     <div className="rounded-lg bg-white p-4 border border-gray-100 shadow-sm transition-all hover:shadow-md hover:-translate-y-px">
@@ -47,7 +52,7 @@ function KpiCard({
         {unit && <span className="ml-1 text-sm text-gray-400">{unit}</span>}
       </p>
       <div className="mt-3 h-1.5 rounded-full bg-gray-100 overflow-hidden">
-        <div className="h-full rounded-full bg-primary-accent" style={{ width: `${pct}%` }} />
+        <div className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: gaugeColor }} />
       </div>
       <p className="mt-2 font-mono text-xs" style={{ color: trend.color }}>{trend.label}</p>
     </div>


### PR DESCRIPTION
## 변경 내용
- front_app 디자인 토큰을 front_web 기준으로 통일
- 대시보드/뉴스/지표/설정/예측 화면의 색상 가시성 정리
- app/web 대시보드 KPI 게이지 색상 로직을 단계형 색상으로 통일
- lint 대상에서 Expo 빌드 산출물 제외
- useNews hook dependency warning 정리

## 검증
- cd front_app && npm run lint
- cd front_web && npm run build

Closes #89