### PR TITLE
fix: release port 80 before nginx restart (#100)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -101,6 +101,11 @@ jobs:
             }
             EOF
 
+            echo "[10.1/13] Release port 80 from any existing web service"
+            sudo systemctl stop apache2 2>/dev/null || true
+            sudo systemctl stop nginx 2>/dev/null || true
+            sudo fuser -k 80/tcp 2>/dev/null || true
+
             sudo rm -f /etc/nginx/sites-enabled/default
             sudo ln -sf "$NGINX_SITE" /etc/nginx/sites-enabled/costview-backend
             sudo nginx -t


### PR DESCRIPTION
## Summary
- stop common web services before restarting nginx
- free up port 80 if another process is still holding it
- keep the nginx reverse proxy deployment path intact

## Verification
- reviewed the failed deployment log from run 24866869173
- will re-run the backend deployment workflow after merge
